### PR TITLE
Send in nonblocking loop

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pip>=23.3
 bump2version==0.5.11
-wheel==0.33.6
+wheel>=0.38.1
 watchdog==0.9.0
 tox==3.14.0
 coverage==4.5.4


### PR DESCRIPTION
This replaces the handling of sending telemetry data when no event loop is available with a spawn of a new process which the event loop runs in.