### PR TITLE
13 Update naming conventions and config structure

### DIFF
--- a/config_diff.git
+++ b/config_diff.git
@@ -1,0 +1,322 @@
+diff --git a/src/access_py_telemetry/__init__.py b/src/access_py_telemetry/__init__.py
+index e32d12b..c59a60e 100644
+--- a/src/access_py_telemetry/__init__.py
++++ b/src/access_py_telemetry/__init__.py
+@@ -11,8 +11,9 @@ from IPython.core.interactiveshell import InteractiveShell
+ 
+ from . import _version
+ from .ast import capture_registered_calls
+-from .api import SessionID, ENDPOINTS  # noqa
+-from .registry import REGISTRIES, RegisterWarning
++from .api import SessionID  # noqa
++from .registry import RegisterWarning
++from .utils import ENDPOINTS, REGISTRIES
+ 
+ 
+ # Make sure that our registries & endpoints match up
+diff --git a/src/access_py_telemetry/api.py b/src/access_py_telemetry/api.py
+index 82396b7..526db5f 100644
+--- a/src/access_py_telemetry/api.py
++++ b/src/access_py_telemetry/api.py
+@@ -13,6 +13,7 @@ import asyncio
+ import pydantic
+ import yaml
+ from pathlib import Path
++from .utils import ENDPOINTS, REGISTRIES
+ 
+ S = TypeVar("S", bound="SessionID")
+ H = TypeVar("H", bound="ApiHandler")
+@@ -20,8 +21,6 @@ H = TypeVar("H", bound="ApiHandler")
+ with open(Path(__file__).parent / "config.yaml", "r") as f:
+     config = yaml.safe_load(f)
+ 
+-ENDPOINTS = {registry: content.get("endpoint") for registry, content in config.items()}
+-REGISTRIES = {registry for registry in config.keys()}
+ SERVER_URL = "https://tracking-services-d6c2fd311c12.herokuapp.com"
+ 
+ 
+@@ -36,11 +35,9 @@ class ApiHandler:
+ 
+     _instance = None
+     _server_url = SERVER_URL[:]
+-    endpoints = {key: val for key, val in ENDPOINTS.items()}
+-    registries = {key for key in REGISTRIES}
+-    _extra_fields: dict[str, dict[str, Any]] = {
+-        ep_name: {} for ep_name in ENDPOINTS.keys()
+-    }
++    endpoints = {service: endpoint for service, endpoint in ENDPOINTS.items()}
++    registries = {service for service in REGISTRIES}
++    _extra_fields: dict[str, dict[str, Any]] = {ep_name: {} for ep_name in ENDPOINTS}
+     _pop_fields: dict[str, list[str]] = {}
+ 
+     def __new__(cls: Type[H]) -> H:
+diff --git a/src/access_py_telemetry/ast.py b/src/access_py_telemetry/ast.py
+index 8488f60..e333557 100644
+--- a/src/access_py_telemetry/ast.py
++++ b/src/access_py_telemetry/ast.py
+@@ -9,7 +9,8 @@ from IPython.core.getipython import get_ipython
+ from IPython.core.interactiveshell import ExecutionInfo
+ 
+ from .api import ApiHandler
+-from .registry import TelemetryRegister, REGISTRIES
++from .registry import TelemetryRegister
++from .utils import REGISTRIES
+ 
+ 
+ api_handler = ApiHandler()
+diff --git a/src/access_py_telemetry/config.yaml b/src/access_py_telemetry/config.yaml
+index 29ad955..d8023db 100644
+--- a/src/access_py_telemetry/config.yaml
++++ b/src/access_py_telemetry/config.yaml
+@@ -1,10 +1,10 @@
+-catalog:
+-  endpoint: /intake/update
+-  items:
++intake:
++  catalog:
+     - esm_datastore.search
+     - DfFileCatalog.search
+     - DfFileCatalog.__getitem__
+ payu: 
+-  endpoint: /payu/update
+-  items:
++  run: 
+     - Experiment.run
++  restart:
++    - Experiment.restart
+\ No newline at end of file
+diff --git a/src/access_py_telemetry/registry.py b/src/access_py_telemetry/registry.py
+index f74b416..5bf3090 100644
+--- a/src/access_py_telemetry/registry.py
++++ b/src/access_py_telemetry/registry.py
+@@ -4,20 +4,12 @@ SPDX-License-Identifier: Apache-2.0
+ """
+ 
+ from typing import Type, TypeVar, Iterator, Callable, Any
+-from pathlib import Path
+ import pydantic
+-import yaml
+ import copy
++from .utils import REGISTRIES
+ 
+ T = TypeVar("T", bound="TelemetryRegister")
+ 
+-with open(Path(__file__).parent / "config.yaml", "r") as f:
+-    config = yaml.safe_load(f)
+-
+-REGISTRIES = {
+-    registry: set(content.get("items")) for registry, content in config.items()
+-}
+-
+ 
+ class RegisterWarning(UserWarning):
+     """
+@@ -33,8 +25,6 @@ class TelemetryRegister:
+     this class is going to be a singleton so that we can register functions to it
+     from anywhere and have them persist across all telemetry calls.
+ 
+-    This doesn't actually work - we are going to need one registry per service, so
+-    we can't use a singleton here. We'll need to refactor this later.
+     """
+ 
+     # Set of registered functions for now - we can add more later or dynamically
+diff --git a/src/access_py_telemetry/utils.py b/src/access_py_telemetry/utils.py
+new file mode 100644
+index 0000000..7ed1986
+--- /dev/null
++++ b/src/access_py_telemetry/utils.py
+@@ -0,0 +1,54 @@
++"""
++Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
++SPDX-License-Identifier: Apache-2.0
++"""
++
++from typing import Any
++import yaml
++from pathlib import Path
++from dataclasses import dataclass, field
++
++
++with open(Path(__file__).parent / "config.yaml", "r") as f:
++    config = yaml.safe_load(f)
++
++
++@dataclass
++class TelemetryRegister:
++    endpoint: str
++    items: set[str] = field(default_factory=set)
++
++
++def build_endpoints(
++    config: dict[str, Any], parent: str | None = None
++) -> list[TelemetryRegister]:
++    """
++    Recursively join the keys of the dictionary until we reach a list
++    Returns list of tuples (path, endpoint_list)
++    """
++    parent = parent or ""
++    results = []
++
++    for key, val in config.items():
++        if isinstance(val, dict):
++            # Recursively process dictionaries and extend results
++            nested_results = build_endpoints(val, f"{parent}/{key}" if parent else key)
++            results.extend(nested_results)
++        elif isinstance(val, list):
++            # Add tuple of (path, list) when we find a list
++            full_path = "/".join([parent, key]) if parent else key
++            results.append(TelemetryRegister(full_path, set(val)))
++
++    return results
++
++
++ENDPOINTS = {
++    register.endpoint.replace("/", "_"): register.endpoint
++    for register in build_endpoints(config)
++}
++
++REGISTRIES = {
++    register.endpoint.replace("/", "_"): register.items
++    for register in build_endpoints(config)
++}
++SERVER_URL = "https://tracking-services-d6c2fd311c12.herokuapp.com"
+diff --git a/tests/test_api.py b/tests/test_api.py
+index 2cd9f8c..c771206 100644
+--- a/tests/test_api.py
++++ b/tests/test_api.py
+@@ -74,15 +74,20 @@ def test_api_handler_extra_fields(local_host, api_handler):
+     with pytest.raises(AttributeError):
+         session1.extra_fields = {"catalog_version": "1.0"}
+ 
+-    session1.add_extra_fields("catalog", {"version": "1.0"})
++    XF_NAME = "intake_catalog"
+ 
+-    blank_registries = {key: {} for key in session1.registries if key != "catalog"}
++    session1.add_extra_fields(XF_NAME, {"version": "1.0"})
+ 
+-    assert session2.extra_fields == {"catalog": {"version": "1.0"}, **blank_registries}
++    blank_registries = {key: {} for key in session1.registries if key != XF_NAME}
++
++    assert session2.extra_fields == {
++        "intake_catalog": {"version": "1.0"},
++        **blank_registries,
++    }
+ 
+     with pytest.raises(KeyError) as excinfo:
+-        session1.add_extra_fields("catalogue", {"version": "2.0"})
+-        assert str(excinfo.value) == "Endpoint catalogue not found"
++        session1.add_extra_fields("catalog", {"version": "2.0"})
++        assert str(excinfo.value) == "Endpoint catalog not found"
+ 
+     # Make sure that adding a new sesson doesn't overwrite the old one
+     session3 = ApiHandler()
+@@ -221,7 +226,7 @@ def test_api_handler_invalid_endpoint(api_handler):
+     # of the _extra_fields attribute
+ 
+     api_handler.endpoints = {
+-        "catalog": "/intake/update",
++        "intake_catalog": "/intake/catalog",
+     }
+ 
+     api_handler._extra_fields = {
+diff --git a/tests/test_decorators.py b/tests/test_decorators.py
+index 3021a25..e20470a 100644
+--- a/tests/test_decorators.py
++++ b/tests/test_decorators.py
+@@ -13,7 +13,7 @@ def test_ipy_register_func(api_handler, reset_telemetry_register):
+     """
+ 
+     @ipy_register_func(
+-        service="catalog",
++        service="intake_catalog",
+         extra_fields={"model": "ACCESS-OM2", "random_number": 2},
+         pop_fields=["session_id"],
+     )
+@@ -22,16 +22,18 @@ def test_ipy_register_func(api_handler, reset_telemetry_register):
+ 
+     my_func()
+ 
+-    register = TelemetryRegister("catalog")
++    register = TelemetryRegister("intake_catalog")
+     api_handler = ApiHandler()
+-    blank_registries = {key: {} for key in api_handler.registries if key != "catalog"}
++    blank_registries = {
++        key: {} for key in api_handler.registries if key != "intake_catalog"
++    }
+ 
+     assert api_handler.extra_fields == {
+-        "catalog": {"model": "ACCESS-OM2", "random_number": 2},
++        "intake_catalog": {"model": "ACCESS-OM2", "random_number": 2},
+         **blank_registries,
+     }
+ 
+-    assert api_handler.pop_fields == {"catalog": ["session_id"]}
++    assert api_handler.pop_fields == {"intake_catalog": ["session_id"]}
+ 
+     assert my_func.__name__ in register
+ 
+@@ -47,24 +49,26 @@ async def test_register_func(api_handler, reset_telemetry_register):
+     """
+ 
+     @register_func(
+-        service="catalog",
++        service="intake_catalog",
+         extra_fields={"model": "ACCESS-OM2", "random_number": 2},
+         pop_fields=["session_id"],
+     )
+     def my_func():
+         pass
+ 
+-    register = TelemetryRegister("catalog")
++    register = TelemetryRegister("intake_catalog")
+     api_handler = ApiHandler()
+ 
+-    blank_registries = {key: {} for key in api_handler.registries if key != "catalog"}
++    blank_registries = {
++        key: {} for key in api_handler.registries if key != "intake_catalog"
++    }
+ 
+     assert api_handler.extra_fields == {
+-        "catalog": {"model": "ACCESS-OM2", "random_number": 2},
++        "intake_catalog": {"model": "ACCESS-OM2", "random_number": 2},
+         **blank_registries,
+     }
+ 
+-    assert api_handler.pop_fields == {"catalog": ["session_id"]}
++    assert api_handler.pop_fields == {"intake_catalog": ["session_id"]}
+ 
+     assert my_func.__name__ in register
+ 
+diff --git a/tests/test_registry.py b/tests/test_registry.py
+index e37b0cb..42b469a 100644
+--- a/tests/test_registry.py
++++ b/tests/test_registry.py
+@@ -14,8 +14,8 @@ def test_telemetry_register_unique(reset_telemetry_register):
+     and deregister functions as we would expect.
+     """
+     TelemetryRegister._instances = {}
+-    session1 = TelemetryRegister("catalog")
+-    session2 = TelemetryRegister("catalog")
++    session1 = TelemetryRegister("intake_catalog")
++    session2 = TelemetryRegister("intake_catalog")
+ 
+     # assert session1 is session2
+ 
+@@ -36,7 +36,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
+ 
+     session1.deregister("test_function", "DfFileCatalog.__getitem__")
+ 
+-    session3 = TelemetryRegister("catalog")
++    session3 = TelemetryRegister("intake_catalog")
+ 
+     assert set(session3) == {
+         "esm_datastore.search",
+@@ -50,7 +50,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
+ 
+ 
+ def test_telemetry_register_validation(reset_telemetry_register):
+-    session_register = TelemetryRegister("catalog")
++    session_register = TelemetryRegister("intake_catalog")
+ 
+     with pytest.raises(ValidationError):
+         session_register.register(1.0)

--- a/src/access_py_telemetry/__init__.py
+++ b/src/access_py_telemetry/__init__.py
@@ -11,8 +11,9 @@ from IPython.core.interactiveshell import InteractiveShell
 
 from . import _version
 from .ast import capture_registered_calls
-from .api import SessionID, ENDPOINTS  # noqa
-from .registry import REGISTRIES, RegisterWarning
+from .api import SessionID  # noqa
+from .registry import RegisterWarning
+from .utils import ENDPOINTS, REGISTRIES
 
 
 # Make sure that our registries & endpoints match up

--- a/src/access_py_telemetry/api.py
+++ b/src/access_py_telemetry/api.py
@@ -13,6 +13,7 @@ import asyncio
 import pydantic
 import yaml
 from pathlib import Path
+from .utils import ENDPOINTS, REGISTRIES
 
 S = TypeVar("S", bound="SessionID")
 H = TypeVar("H", bound="ApiHandler")
@@ -20,8 +21,6 @@ H = TypeVar("H", bound="ApiHandler")
 with open(Path(__file__).parent / "config.yaml", "r") as f:
     config = yaml.safe_load(f)
 
-ENDPOINTS = {registry: content.get("endpoint") for registry, content in config.items()}
-REGISTRIES = {registry for registry in config.keys()}
 SERVER_URL = "https://tracking-services-d6c2fd311c12.herokuapp.com"
 
 
@@ -36,11 +35,9 @@ class ApiHandler:
 
     _instance = None
     _server_url = SERVER_URL[:]
-    endpoints = {key: val for key, val in ENDPOINTS.items()}
-    registries = {key for key in REGISTRIES}
-    _extra_fields: dict[str, dict[str, Any]] = {
-        ep_name: {} for ep_name in ENDPOINTS.keys()
-    }
+    endpoints = {service: endpoint for service, endpoint in ENDPOINTS.items()}
+    registries = {service for service in REGISTRIES}
+    _extra_fields: dict[str, dict[str, Any]] = {ep_name: {} for ep_name in ENDPOINTS}
     _pop_fields: dict[str, list[str]] = {}
 
     def __new__(cls: Type[H]) -> H:

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -9,7 +9,8 @@ from IPython.core.getipython import get_ipython
 from IPython.core.interactiveshell import ExecutionInfo
 
 from .api import ApiHandler
-from .registry import TelemetryRegister, REGISTRIES
+from .registry import TelemetryRegister
+from .utils import REGISTRIES
 
 
 api_handler = ApiHandler()

--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -1,10 +1,10 @@
-catalog:
-  endpoint: /intake/update
-  items:
+intake:
+  catalog:
     - esm_datastore.search
     - DfFileCatalog.search
     - DfFileCatalog.__getitem__
 payu: 
-  endpoint: /payu/update
-  items:
+  run: 
     - Experiment.run
+  restart:
+    - Experiment.restart

--- a/src/access_py_telemetry/registry.py
+++ b/src/access_py_telemetry/registry.py
@@ -4,19 +4,11 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from typing import Type, TypeVar, Iterator, Callable, Any
-from pathlib import Path
 import pydantic
-import yaml
 import copy
+from .utils import REGISTRIES
 
 T = TypeVar("T", bound="TelemetryRegister")
-
-with open(Path(__file__).parent / "config.yaml", "r") as f:
-    config = yaml.safe_load(f)
-
-REGISTRIES = {
-    registry: set(content.get("items")) for registry, content in config.items()
-}
 
 
 class RegisterWarning(UserWarning):
@@ -33,8 +25,6 @@ class TelemetryRegister:
     this class is going to be a singleton so that we can register functions to it
     from anywhere and have them persist across all telemetry calls.
 
-    This doesn't actually work - we are going to need one registry per service, so
-    we can't use a singleton here. We'll need to refactor this later.
     """
 
     # Set of registered functions for now - we can add more later or dynamically

--- a/src/access_py_telemetry/utils.py
+++ b/src/access_py_telemetry/utils.py
@@ -1,0 +1,54 @@
+"""
+Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Any
+import yaml
+from pathlib import Path
+from dataclasses import dataclass, field
+
+
+with open(Path(__file__).parent / "config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+
+@dataclass
+class TelemetryRegister:
+    endpoint: str
+    items: set[str] = field(default_factory=set)
+
+
+def build_endpoints(
+    config: dict[str, Any], parent: str | None = None
+) -> list[TelemetryRegister]:
+    """
+    Recursively join the keys of the dictionary until we reach a list
+    Returns list of tuples (path, endpoint_list)
+    """
+    parent = parent or ""
+    results = []
+
+    for key, val in config.items():
+        if isinstance(val, dict):
+            # Recursively process dictionaries and extend results
+            nested_results = build_endpoints(val, f"{parent}/{key}" if parent else key)
+            results.extend(nested_results)
+        elif isinstance(val, list):
+            # Add tuple of (path, list) when we find a list
+            full_path = "/".join([parent, key]) if parent else key
+            results.append(TelemetryRegister(full_path, set(val)))
+
+    return results
+
+
+ENDPOINTS = {
+    register.endpoint.replace("/", "_"): register.endpoint
+    for register in build_endpoints(config)
+}
+
+REGISTRIES = {
+    register.endpoint.replace("/", "_"): register.items
+    for register in build_endpoints(config)
+}
+SERVER_URL = "https://tracking-services-d6c2fd311c12.herokuapp.com"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,15 +74,20 @@ def test_api_handler_extra_fields(local_host, api_handler):
     with pytest.raises(AttributeError):
         session1.extra_fields = {"catalog_version": "1.0"}
 
-    session1.add_extra_fields("catalog", {"version": "1.0"})
+    XF_NAME = "intake_catalog"
 
-    blank_registries = {key: {} for key in session1.registries if key != "catalog"}
+    session1.add_extra_fields(XF_NAME, {"version": "1.0"})
 
-    assert session2.extra_fields == {"catalog": {"version": "1.0"}, **blank_registries}
+    blank_registries = {key: {} for key in session1.registries if key != XF_NAME}
+
+    assert session2.extra_fields == {
+        "intake_catalog": {"version": "1.0"},
+        **blank_registries,
+    }
 
     with pytest.raises(KeyError) as excinfo:
-        session1.add_extra_fields("catalogue", {"version": "2.0"})
-        assert str(excinfo.value) == "Endpoint catalogue not found"
+        session1.add_extra_fields("catalog", {"version": "2.0"})
+        assert str(excinfo.value) == "Endpoint catalog not found"
 
     # Make sure that adding a new sesson doesn't overwrite the old one
     session3 = ApiHandler()
@@ -221,7 +226,7 @@ def test_api_handler_invalid_endpoint(api_handler):
     # of the _extra_fields attribute
 
     api_handler.endpoints = {
-        "catalog": "/intake/update",
+        "intake_catalog": "/intake/catalog",
     }
 
     api_handler._extra_fields = {

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -13,7 +13,7 @@ def test_ipy_register_func(api_handler, reset_telemetry_register):
     """
 
     @ipy_register_func(
-        service="catalog",
+        service="intake_catalog",
         extra_fields={"model": "ACCESS-OM2", "random_number": 2},
         pop_fields=["session_id"],
     )
@@ -22,16 +22,18 @@ def test_ipy_register_func(api_handler, reset_telemetry_register):
 
     my_func()
 
-    register = TelemetryRegister("catalog")
+    register = TelemetryRegister("intake_catalog")
     api_handler = ApiHandler()
-    blank_registries = {key: {} for key in api_handler.registries if key != "catalog"}
+    blank_registries = {
+        key: {} for key in api_handler.registries if key != "intake_catalog"
+    }
 
     assert api_handler.extra_fields == {
-        "catalog": {"model": "ACCESS-OM2", "random_number": 2},
+        "intake_catalog": {"model": "ACCESS-OM2", "random_number": 2},
         **blank_registries,
     }
 
-    assert api_handler.pop_fields == {"catalog": ["session_id"]}
+    assert api_handler.pop_fields == {"intake_catalog": ["session_id"]}
 
     assert my_func.__name__ in register
 
@@ -47,24 +49,26 @@ async def test_register_func(api_handler, reset_telemetry_register):
     """
 
     @register_func(
-        service="catalog",
+        service="intake_catalog",
         extra_fields={"model": "ACCESS-OM2", "random_number": 2},
         pop_fields=["session_id"],
     )
     def my_func():
         pass
 
-    register = TelemetryRegister("catalog")
+    register = TelemetryRegister("intake_catalog")
     api_handler = ApiHandler()
 
-    blank_registries = {key: {} for key in api_handler.registries if key != "catalog"}
+    blank_registries = {
+        key: {} for key in api_handler.registries if key != "intake_catalog"
+    }
 
     assert api_handler.extra_fields == {
-        "catalog": {"model": "ACCESS-OM2", "random_number": 2},
+        "intake_catalog": {"model": "ACCESS-OM2", "random_number": 2},
         **blank_registries,
     }
 
-    assert api_handler.pop_fields == {"catalog": ["session_id"]}
+    assert api_handler.pop_fields == {"intake_catalog": ["session_id"]}
 
     assert my_func.__name__ in register
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,8 +14,8 @@ def test_telemetry_register_unique(reset_telemetry_register):
     and deregister functions as we would expect.
     """
     TelemetryRegister._instances = {}
-    session1 = TelemetryRegister("catalog")
-    session2 = TelemetryRegister("catalog")
+    session1 = TelemetryRegister("intake_catalog")
+    session2 = TelemetryRegister("intake_catalog")
 
     # assert session1 is session2
 
@@ -36,7 +36,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
 
     session1.deregister("test_function", "DfFileCatalog.__getitem__")
 
-    session3 = TelemetryRegister("catalog")
+    session3 = TelemetryRegister("intake_catalog")
 
     assert set(session3) == {
         "esm_datastore.search",
@@ -50,7 +50,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
 
 
 def test_telemetry_register_validation(reset_telemetry_register):
-    session_register = TelemetryRegister("catalog")
+    session_register = TelemetryRegister("intake_catalog")
 
     with pytest.raises(ValidationError):
         session_register.register(1.0)


### PR DESCRIPTION
- Restructure how configuration works, with service names being built procedurally from the config.yaml file.
- Moved functionality to read config, build registry options etc etc off to a separate utils.py file.
- Updated tests to respect new structure

TODO:
- [ ] Update readme.
- [ ] Field testing.