### PR TITLE
Change handling of multiprocessing

### DIFF
--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -21,3 +21,4 @@ dependencies:
     - codecov
     - pytest-asyncio==0.25.0
     - pytest-random-order==1.1.1
+    - pytest_httpserver==1.1.1

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -21,3 +21,4 @@ dependencies:
     - codecov
     - pytest-asyncio==0.25.0
     - pytest-random-order==1.1.1
+    - pytest_httpserver==1.1.1

--- a/ci/environment-3.12.yml
+++ b/ci/environment-3.12.yml
@@ -21,3 +21,4 @@ dependencies:
     - codecov
     - pytest-asyncio==0.25.0
     - pytest-random-order==1.1.1
+    - pytest_httpserver==1.1.1

--- a/ci/environment-3.13.yml
+++ b/ci/environment-3.13.yml
@@ -21,3 +21,4 @@ dependencies:
     - codecov
     - pytest-asyncio==0.25.0
     - pytest-random-order==1.1.1
+    - pytest_httpserver==1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "mypy",  # linting
     "pytest",  # testing
     "ruff",  # linting
+    "pytest-httpserver", # #Endpoints for testing.
 ]
 
 [project.scripts]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -249,7 +249,7 @@ def test_send_in_loop_is_bg(httpserver: HTTPServer):
 
     dt = end_time - start_time
 
-    assert dt < 2
+    assert dt < 4
     assert len(httpserver.log) == 6
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from access_py_telemetry.api import (
 )
 from pydantic import ValidationError
 import pytest
-from pytest_httpserver import HTTPServer
+from pytest_httpserver import HTTPServer, RequestMatcher
 import time
 
 
@@ -227,7 +227,7 @@ def test_send_in_loop_is_bg(httpserver: HTTPServer):
     testing the process startup/teardown time.
     """
     httpserver.expect_request("/loop-endpoint").respond_with_data("Request received")
-    start_time = time.time()
+    httpserver.expect_request("/slow-endpoint").respond_with_handler(time.sleep(2))
 
     assert len(httpserver.log) == 0
 
@@ -236,16 +236,21 @@ def test_send_in_loop_is_bg(httpserver: HTTPServer):
             endpoint=httpserver.url_for("/loop-endpoint"), telemetry_data={}, timeout=3
         )
 
-    print("Requests sent")
+    httpserver.assert_request_made(RequestMatcher("/loop-endpoint"), count=3)
+    assert len(httpserver.log) == 3
 
-    time.sleep(2)
+    start_time = time.time()
+    for _ in range(3):
+        send_in_loop(
+            endpoint=httpserver.url_for("/sleep-endpoint"), telemetry_data={}, timeout=3
+        )
 
     end_time = time.time()
 
     dt = end_time - start_time
 
-    assert dt < 4
-    assert len(httpserver.log) == 3
+    assert dt < 2
+    assert len(httpserver.log) == 6
 
 
 def test_api_handler_invalid_endpoint(api_handler):


### PR DESCRIPTION
Closes #20 .

- Updates event loop stuff to use a context instead of a global start method set.
- Tests that our requests are actually sent in the background to the correct place.
- Update CI environments to add pytest-httpserver.