### PR TITLE
Trailing slashes

### DIFF
--- a/src/access_py_telemetry/api.py
+++ b/src/access_py_telemetry/api.py
@@ -17,7 +17,7 @@ import yaml
 import multiprocessing
 from pathlib import Path, PurePosixPath
 
-from .utils import ENDPOINTS, REGISTRIES
+from .utils import ENDPOINTS
 
 S = TypeVar("S", bound="SessionID")
 H = TypeVar("H", bound="ApiHandler")
@@ -43,7 +43,6 @@ class ApiHandler:
     _instance = None
     _server_url = SERVER_URL[:]
     endpoints = {service: endpoint for service, endpoint in ENDPOINTS.items()}
-    registries = {service for service in REGISTRIES}
     _extra_fields: dict[str, dict[str, Any]] = {ep_name: {} for ep_name in ENDPOINTS}
     _pop_fields: dict[str, list[str]] = {}
     _request_timeout = None
@@ -405,4 +404,4 @@ def _format_endpoint(server_url: str, endpoint: str) -> str:
     slash between them.
     """
     endpoint = str(PurePosixPath(server_url) / endpoint.lstrip("/"))
-    return re.sub(r"^(https?:/)", r"\1/", endpoint)
+    return re.sub(r"^(https?:/)(.*?)(?<!/)\/?$", r"\1/\2/", endpoint)

--- a/src/access_py_telemetry/utils.py
+++ b/src/access_py_telemetry/utils.py
@@ -51,4 +51,3 @@ REGISTRIES = {
     register.endpoint.replace("/", "_"): register.items
     for register in build_endpoints(config)
 }
-SERVER_URL = "https://tracking-services-d6c2fd311c12.herokuapp.com"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # type: ignore
 from pytest import fixture
-from access_py_telemetry.api import ApiHandler, ENDPOINTS, SERVER_URL, REGISTRIES
+from access_py_telemetry.api import ApiHandler, SERVER_URL
+from access_py_telemetry.utils import ENDPOINTS
 from access_py_telemetry.registry import TelemetryRegister
 
 
@@ -15,7 +16,6 @@ def api_handler():
     ApiHandler._instance = None
     ApiHandler._server_url = SERVER_URL[:]
     ApiHandler.endpoints = {key: val for key, val in ENDPOINTS.items()}
-    ApiHandler.registries = {key for key in REGISTRIES}
     ApiHandler._extra_fields = {ep_name: {} for ep_name in ENDPOINTS.keys()}
     ApiHandler._pop_fields = {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,7 +84,7 @@ def test_api_handler_extra_fields(local_host, api_handler):
 
     session1.add_extra_fields(XF_NAME, {"version": "1.0"})
 
-    blank_registries = {key: {} for key in session1.registries if key != XF_NAME}
+    blank_registries = {key: {} for key in session1.endpoints if key != XF_NAME}
 
     assert session2.extra_fields == {
         "intake_catalog": {"version": "1.0"},
@@ -307,22 +307,22 @@ def test_api_handler_set_timeout(api_handler):
         (
             "http://localhost:8000",
             "/some/endpoint",
-            "http://localhost:8000/some/endpoint",
+            "http://localhost:8000/some/endpoint/",
         ),
         (
             "http://localhost:8000/",
             "some/endpoint/",
-            "http://localhost:8000/some/endpoint",
+            "http://localhost:8000/some/endpoint/",
         ),
         (
             "https://localhost:8000",
             "/some/endpoint",
-            "https://localhost:8000/some/endpoint",
+            "https://localhost:8000/some/endpoint/",
         ),
         (
             "https://localhost:8000/",
             "some/endpoint/",
-            "https://localhost:8000/some/endpoint",
+            "https://localhost:8000/some/endpoint/",
         ),
     ],
 )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -25,7 +25,7 @@ def test_ipy_register_func(api_handler, reset_telemetry_register):
     register = TelemetryRegister("intake_catalog")
     api_handler = ApiHandler()
     blank_registries = {
-        key: {} for key in api_handler.registries if key != "intake_catalog"
+        key: {} for key in api_handler.endpoints if key != "intake_catalog"
     }
 
     assert api_handler.extra_fields == {
@@ -60,7 +60,7 @@ async def test_register_func(api_handler, reset_telemetry_register):
     api_handler = ApiHandler()
 
     blank_registries = {
-        key: {} for key in api_handler.registries if key != "intake_catalog"
+        key: {} for key in api_handler.endpoints if key != "intake_catalog"
     }
 
     assert api_handler.extra_fields == {


### PR DESCRIPTION
- Add trailing slash to API calls
- Removed unnecessary extra set in API handler - registries is just endpoints keys.