### PR TITLE
Remove username collection from default telemetry

### DIFF
--- a/src/access_py_telemetry/api.py
+++ b/src/access_py_telemetry/api.py
@@ -5,10 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Type, TypeVar, Iterable
 import warnings
-import getpass
 import platform
-import datetime
-import hashlib
+import uuid
 import httpx
 import asyncio
 import pydantic
@@ -190,7 +188,7 @@ class ApiHandler:
         aren't. I've also modified __get__, so SessionID() evaluates to a string.
         """
         telemetry_data = {
-            "name": getpass.getuser(),
+            # "name": getpass.getuser(), # Until we work out the privacy policy nightmare
             "function": function_name,
             "args": args,
             "kwargs": kwargs,
@@ -211,8 +209,7 @@ class SessionID:
 
     This class ensures that only one instance of the session ID exists. The session
     ID is generated the first time it is accessed and is represented as a string.
-    The session ID is created using the current user's login name and the current
-    timestamp, hashed with SHA-256.
+    The session ID is created using using the UUID4 algorithm.
 
     Methods:
         __new__(cls, *args, **kwargs): Ensures only one instance of the class is created.
@@ -240,11 +237,10 @@ class SessionID:
 
     @staticmethod
     def create_session_id() -> str:
-        login = getpass.getuser()
-        timestamp = datetime.datetime.now().isoformat()
-        session_str = f"{login}_{timestamp}"
-        session_id = hashlib.sha256((session_str).encode()).hexdigest()
-        return session_id
+        """
+        Generate a unique session ID.
+        """
+        return str(uuid.uuid4())
 
 
 async def send_telemetry(endpoint: str, data: dict[str, Any]) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,7 +40,7 @@ def test_session_id_properties():
 
     assert type(id1) is str
 
-    assert len(id1) == 64
+    assert len(id1) == 36
 
     assert id1 != SessionID.create_session_id()
 
@@ -196,7 +196,7 @@ def test_api_handler_send_api_request(api_handler, capsys):
     api_handler.add_extra_fields("payu", {"model": "ACCESS-OM2", "random_number": 2})
 
     # Remove indeterminate fields
-    api_handler.remove_fields("payu", ["session_id", "name"])
+    api_handler.remove_fields("payu", ["session_id"])
 
     # We should get a warning because we've used a dud url, but pytest doesn't
     # seem to capture subprocess warnings. I'm not sure there is really a good
@@ -205,13 +205,13 @@ def test_api_handler_send_api_request(api_handler, capsys):
         service_name="payu",
         function_name="_test",
         args=[1, 2, 3],
-        kwargs={"name": "test_username"},
+        kwargs={"random": "item"},
     )
 
     assert api_handler._last_record == {
         "function": "_test",
         "args": [1, 2, 3],
-        "kwargs": {"name": "test_username"},
+        "kwargs": {"random": "item"},
         "model": "ACCESS-OM2",
         "random_number": 2,
     }


### PR DESCRIPTION
It sounds like collecting username data is going to be unworkable in the immediate future, until we get a privacy policy worked out regarding this stuff.

This PR removed default username collection - N.B it doesn't prevent it being re-added at runtime by someone who is really determined.

@rbeucher does it sound sensible to you for us to start collecting telemetry without any user data until we get the privacy policy figured out?

