### PR TITLE
Draft list of things to track for intake catalog usage

### DIFF
--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -3,8 +3,21 @@ intake:
     - esm_datastore.search
     - DfFileCatalog.search
     - DfFileCatalog.__getitem__
-payu: 
-  run: 
-    - Experiment.run
-  restart:
-    - Experiment.restart
+    - esm_datastore.to_dataset_dict
+    - esm_datastore.to_dask
+    - esm_datastore.df
+    - DfFileCatalog.df
+    - esm_datastore.unique
+    - DfFileCatalog.unique
+    - DfFileCatalog.keys
+    - DfFileCatalog.to_source_dict
+    - DfFileCatalog.to_source
+  datastore:
+    - use_datastore
+    - intake.open_esm_datastore
+    - BaseBuilder.build
+    - BaseBuilder.save
+  cli:
+    - metadata_validate
+    - metadata_template
+    - use_esm_datatore

--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -12,9 +12,11 @@ intake:
     - DfFileCatalog.keys
     - DfFileCatalog.to_source_dict
     - DfFileCatalog.to_source
+    - open_catalog
+    - Catalog.__init__
   datastore:
     - use_datastore
-    - intake.open_esm_datastore
+    - open_esm_datastore
     - BaseBuilder.build
     - BaseBuilder.save
   cli:

--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -8,7 +8,9 @@ intake:
     - esm_datastore.df
     - DfFileCatalog.df
     - esm_datastore.unique
+    - esm_datastore.nunique
     - DfFileCatalog.unique
+    - DfFileCatalog.nunique
     - DfFileCatalog.keys
     - DfFileCatalog.to_source_dict
     - DfFileCatalog.to_source
@@ -31,6 +33,8 @@ intake:
     - AccessEsm15Builder.save
     - AccessCm2Builder.build
     - AccessCm2Builder.save
+    - ROMSBuilder.build
+    - ROMSBuilder.save
   cli:
     - metadata_validate
     - metadata_template

--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -19,6 +19,18 @@ intake:
     - open_esm_datastore
     - BaseBuilder.build
     - BaseBuilder.save
+    - AccessOm2Builder.build
+    - AccessOm2Builder.save
+    - AccessOm3Builder.build
+    - AccessOm3Builder.save
+    - AccessCm2Builder.build
+    - AccessCm2Builder.save
+    - Mom6Builder.build
+    - Mom6Builder.save
+    - AccessEsm15Builder.build
+    - AccessEsm15Builder.save
+    - AccessCm2Builder.build
+    - AccessCm2Builder.save
   cli:
     - metadata_validate
     - metadata_template

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -19,7 +19,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
 
     # assert session1 is session2
 
-    assert set(session1) == {
+    assert set(session1) >= {
         "esm_datastore.search",
         "DfFileCatalog.search",
         "DfFileCatalog.__getitem__",
@@ -27,7 +27,7 @@ def test_telemetry_register_unique(reset_telemetry_register):
 
     session1.register("test_function")
 
-    assert set(session2) == {
+    assert set(session2) >= {
         "esm_datastore.search",
         "DfFileCatalog.search",
         "DfFileCatalog.__getitem__",
@@ -38,15 +38,21 @@ def test_telemetry_register_unique(reset_telemetry_register):
 
     session3 = TelemetryRegister("intake_catalog")
 
-    assert set(session3) == {
+    assert set(session3) >= {
         "esm_datastore.search",
         "DfFileCatalog.search",
     }
 
-    assert set(session2) == {
+    assert "test_function" not in session3
+    assert "DfFileCatalog.__getitem__" not in session3
+
+    assert set(session2) >= {
         "esm_datastore.search",
         "DfFileCatalog.search",
     }
+
+    assert "test_function" not in session2
+    assert "DfFileCatalog.__getitem__" not in session2
 
 
 def test_telemetry_register_validation(reset_telemetry_register):


### PR DESCRIPTION
This PR adds a bunch of things we might want to track from the intake catalog.

I've broken them up into endpoints based on where they sort of philosophically belong - so stuff relating to catalog usage will go to `/api/intake/catalog`, stuff relating to datastore usage will go to `/api/intake/datastore`, and cli tool usage to `/api/intake/cli`.

The TLDR of how this works is we use an AST to listen for any of the function calls listed in this config.yaml, and then we post details about their usage to the relevant endpoint if they are called - along with time, a session id, args & kwargs, as well as the catalog version the user is using. 

Are there any other things we might want to track? I've deliberately excluded anything that looks like internals, otherwise we'll just be tracking our development. 