### PR TITLE
30 AST Parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install source
         shell: bash -l {0}
-        run: python -m pip install .
+        run: python -m pip install .[dev]
 
       - name: List installed packages
         shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest",  # testing
     "ruff",  # linting
     "pytest-httpserver", # #Endpoints for testing.
+    "access-nri-intake"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dev = [
     "pytest",  # testing
     "ruff",  # linting
     "pytest-httpserver", # #Endpoints for testing.
-    "access-nri-intake"
+    "intake",
+    "access-nri-intake",
 ]
 
 [project.scripts]

--- a/src/access_py_telemetry/api.py
+++ b/src/access_py_telemetry/api.py
@@ -144,7 +144,7 @@ class ApiHandler:
         service_name: str,
         function_name: str,
         args: list[Any] | tuple[Any, ...],
-        kwargs: dict[str, Any | None],
+        kwargs: dict[str, str | Any],
     ) -> None:
         """
         Send an API request with telemetry data.

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -106,12 +106,14 @@ class CallListener(ast.NodeVisitor):
             else:
                 # Check if the first part is in the user namespace
                 instance = self.user_namespace.get(parts[0])
-                if instance:
-                    class_name = type(instance).__name__
-                    if class_name != "module":
-                        func_name = f"{class_name}.{'.'.join(parts[1:])}"
-                    else:
-                        func_name = f"{instance.__name__}.{'.'.join(parts[1:])}"
+                if not instance:
+                    return None
+
+                class_name = type(instance).__name__
+                if class_name != "module":
+                    func_name = f"{class_name}.{'.'.join(parts[1:])}"
+                else:
+                    func_name = f"{instance.__name__}.{'.'.join(parts[1:])}"
 
         args = [self.safe_eval(arg) for arg in node.args]
         kwargs = {
@@ -140,11 +142,11 @@ class CallListener(ast.NodeVisitor):
         if full_name:
             parts = full_name.split(".")
             instance = self.user_namespace.get(parts[0])
-            if instance:
-                class_name = type(instance).__name__
-                func_name = f"{class_name}.{'.'.join(parts[1:])}__getitem__"
-            else:
-                func_name = f"{full_name}.__getitem__"
+            if not instance:
+                return None
+
+            class_name = type(instance).__name__
+            func_name = f"{class_name}.{'.'.join(parts[1:])}__getitem__"
 
         args = ast.unparse(node.slice)
 

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -72,11 +72,6 @@ class CallListener(ast.NodeVisitor):
             return f"{self._get_full_name(node.value)}.{node.attr}"
         elif isinstance(node, ast.Name):
             return node.id
-        elif isinstance(node, ast.Subscript):
-            # Handle subscript (e.g., mylist[0] -> mylist.__getitem__)
-            value = self._get_full_name(node.value)
-            if value:
-                return f"{value}.__getitem__"
         return None
 
     def safe_eval(self, node: ast.AST) -> Any:
@@ -117,8 +112,6 @@ class CallListener(ast.NodeVisitor):
                         func_name = f"{class_name}.{'.'.join(parts[1:])}"
                     else:
                         func_name = f"{instance.__name__}.{'.'.join(parts[1:])}"
-                else:
-                    print(f"Unknown call: {full_name}")
 
         args = [self.safe_eval(arg) for arg in node.args]
         kwargs = {
@@ -148,8 +141,8 @@ class CallListener(ast.NodeVisitor):
             parts = full_name.split(".")
             instance = self.user_namespace.get(parts[0])
             if instance:
-                registry = type(instance).__name__
-                func_name = f"{registry}.{'.'.join(parts[1:])}__getitem__"
+                class_name = type(instance).__name__
+                func_name = f"{class_name}.{'.'.join(parts[1:])}__getitem__"
             else:
                 func_name = f"{full_name}.__getitem__"
 

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -146,16 +146,12 @@ class CallListener(ast.NodeVisitor):
         func_name = None
         if full_name:
             parts = full_name.split(".")
-            if len(parts) > 0:
-                # Check if the first part is in the user namespace
-                instance = self.user_namespace.get(parts[0])
-                if instance:
-                    registry = type(instance).__name__
-                    func_name = f"{registry}.{'.'.join(parts[1:])}__getitem__"
-                else:
-                    func_name = f"{full_name}.__getitem__"
+            instance = self.user_namespace.get(parts[0])
+            if instance:
+                registry = type(instance).__name__
+                func_name = f"{registry}.{'.'.join(parts[1:])}__getitem__"
             else:
-                print(f"{full_name}.__getitem__")
+                func_name = f"{full_name}.__getitem__"
 
         args = ast.unparse(node.slice)
 

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -107,6 +107,7 @@ class CallListener(ast.NodeVisitor):
                 # Check if the first part is in the user namespace
                 instance = self.user_namespace.get(parts[0])
                 if not instance:
+                    self.generic_visit(node)
                     return None
 
                 class_name = type(instance).__name__

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -119,8 +119,6 @@ class CallListener(ast.NodeVisitor):
                         func_name = f"{instance.__name__}.{'.'.join(parts[1:])}"
                 else:
                     print(f"Unknown call: {full_name}")
-        else:
-            print("Unable to determine call type.")
 
         args = [self.safe_eval(arg) for arg in node.args]
         kwargs = {
@@ -158,8 +156,6 @@ class CallListener(ast.NodeVisitor):
                     func_name = f"{full_name}.__getitem__"
             else:
                 print(f"{full_name}.__getitem__")
-        else:
-            print("Unable to determine subscript operation.")
 
         args = ast.unparse(node.slice)
 

--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -14,8 +14,9 @@ intake:
     - DfFileCatalog.keys
     - DfFileCatalog.to_source_dict
     - DfFileCatalog.to_source
-    - open_catalog
-    - Catalog.__init__
+    - intake.cat.access_nri
+    # - open_catalog
+    # - Catalog.__init__
   datastore:
     - use_datastore
     - open_esm_datastore

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python
+# type: ignore
+
+"""Tests for the AST module"""
+
+import ast
+import pytest
+from access_py_telemetry.ast import CallListener
+from unittest.mock import MagicMock
+
+
+class MockInfo:
+    def __init__(self, raw_cell=None):
+        self.raw_cell = raw_cell
+
+
+# def test_capture_registered_calls():
+#     mock_info = MockInfo()
+#     mock_info.raw_cell = """
+# intake.open_esm_datastore("dud_filename")
+# esm_datastore.search(name='xyz')
+#     """
+
+#     capture_registered_calls(mock_info)
+
+
+def test_ast_instance_method():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    def func(self):
+        self.set_var = set()
+
+    def uncaught_func(self, *args, **kwargs):
+        pass
+
+instance = MyClass()
+mycall = instance.func()
+
+instance.uncaught_func()
+"""
+
+    class MyClass:
+        def func(self):
+            self.set_var = set()
+
+        def uncaught_func(self, *args, **kwargs):
+            pass
+
+    mock_user_ns = {
+        "instance": MyClass(),
+    }
+
+    mock_registry = {"mock": ["MyClass.func"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "MyClass.func",
+    }
+
+    assert "MyClass.uncaught_func" not in visitor._caught_calls
+
+
+def test_ast_bare_function():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+def registered_func():
+    return None
+
+def unregistered_func():
+    return None
+
+registered_func()
+unregistered_func()
+
+"""
+
+    def registered_func():
+        return None
+
+    def unregistered_func():
+        return None
+
+    mock_user_ns = {
+        "registered_func": registered_func,
+        "unregistered_func": unregistered_func,
+    }
+
+    mock_registry = {"mock": ["registered_func"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "registered_func",
+    }
+
+    assert "uncaught_func" not in visitor._caught_calls
+
+
+@pytest.mark.xfail
+def test_ast_aliased_function():
+    """
+    This will require more sophisticated analysis to catch aliased functions. Maybe
+    we can look at this eventually
+    """
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+def registered_func():
+    return None
+
+def unregistered_func():
+    return None
+
+
+reg_func = registered_func
+
+reg_func()
+
+unregistered_func()
+
+"""
+
+    def registered_func():
+        return None
+
+    def unregistered_func():
+        return None
+
+    mock_user_ns = {
+        "registered_func": registered_func,
+        "unregistered_func": unregistered_func,
+        "reg_func": registered_func,
+    }
+
+    mock_registry = {"mock": ["registered_func"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "registered_func",
+    }
+
+    assert "uncaught_func" not in visitor._caught_calls
+
+
+@pytest.mark.xfail
+def test_ast_instantiate_and_call():
+    """
+    Need to figure out how to catch the instantiation of a class and then call a method
+    on it. Not needed yet
+    """
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    def func(self):
+        self.set_var = set()
+
+
+MyClass().func()
+
+"""
+
+    class MyClass:
+        def func(self):
+            self.set_var = set()
+
+    mock_user_ns = {
+        "MyClass": MyClass,
+        "instance": MyClass(),
+    }
+
+    mock_registry = {"mock": ["MyClass.func"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "MyClass.func",
+    }
+
+
+@pytest.mark.xfail
+def test_ast_class_method():
+    """
+    Class methods don't work with the CallListener yet
+    """
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    @classmethod
+    def class_func(cls):
+        self.set_var = set()
+
+    def uncaught_func(self, *args, **kwargs):
+        pass
+
+
+MyClass.func(instance)
+
+"""
+
+    class MyClass:
+        def func(self):
+            self.set_var = set()
+
+    class SecondClass:
+        def other_func(self):
+            self.other_var = 1
+
+    class ClassFunc:
+        @classmethod
+        def class_func(cls):
+            cls.class_var = 1
+
+    def my_bare_func():
+        return None
+
+    mock_user_ns = {
+        "MyClass": MyClass,
+    }
+
+    mock_registry = {"mock": ["MyClass.class_func"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "MyClass.class_func",
+    }
+
+
+def test_ast_indexing():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    def func(self):
+        self.set_var = set()
+
+    def __getitem__(self, key):
+        return [1, 2, 3]
+
+instance = MyClass()
+mycall = instance['some_item']
+
+"""
+
+    class MyClass:
+        def func(self):
+            self.set_var = set()
+
+        def __getitem__(self, key):
+            return [1, 2, 3]
+
+    mock_user_ns = {
+        "MyClass": MyClass,
+        "instance": MyClass(),
+    }
+
+    mock_registry = {"mock": ["MyClass.__getitem__"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "MyClass.__getitem__",
+    }
+
+
+def test_ast_nested_function():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+import os
+
+os.path.join("some","paths")
+
+"""
+
+    import os
+
+    mock_user_ns = {
+        "os": os,
+    }
+
+    mock_registry = {"mock": ["os.path.join"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "os.path.join",
+    }
+
+
+def test_ast_aliased_module():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+import os as operating_system
+
+operating_system.path.join("some","paths")
+
+"""
+
+    import os as operating_system
+
+    mock_user_ns = {
+        "operating_system": operating_system,
+    }
+
+    mock_registry = {"mock": ["os.path.join"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "os.path.join",
+    }
+
+
+def test_import_catalog():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+import intake
+intake.cat.access_nri
+
+"""
+
+    import intake
+
+    mock_user_ns = {
+        "intake": intake,
+        "intake.cat.access_nri": intake.cat.access_nri,
+    }
+
+    mock_registry = {"mock": ["intake.cat.access_nri"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "intake.cat.access_nri",
+    }
+
+
+@pytest.mark.xfail
+def test_import_catalog_traverse_imports():
+    """
+    This fails because the CallListener doesn't traverse the imports yet. We can
+    do this using importlib and then parsing what importlib imports too I think,
+    but let's save that for another day
+    """
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+import intake 
+intake.cat.access_nri
+"""
+
+    import intake
+
+    mock_user_ns = {
+        "intake": intake,
+        "intake.cat.access_nri": intake.cat.access_nri,
+    }
+
+    mock_registry = {"mock": ["intake.catalog.Catalog.__init__"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {
+        "intake.cat.access_nri",
+    }

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -271,6 +271,10 @@ class MyClass:
 instance = MyClass()
 mycall = instance['some_item']
 
+l = [1, 2, 3]
+
+l[0]
+
 """
 
     class MyClass:
@@ -283,9 +287,10 @@ mycall = instance['some_item']
     mock_user_ns = {
         "MyClass": MyClass,
         "instance": MyClass(),
+        "l": [1, 2, 3],
     }
 
-    mock_registry = {"mock": ["MyClass.__getitem__"]}
+    mock_registry = {"mock": ["MyClass.__getitem__", "list.__getitem__"]}
 
     mock_api_handler = MagicMock()
 
@@ -297,6 +302,7 @@ mycall = instance['some_item']
 
     assert visitor._caught_calls == {
         "MyClass.__getitem__",
+        "list.__getitem__",
     }
 
 


### PR DESCRIPTION
Update lots of stuff to make the AST parsing less of a headache & more reliable:
- Actually test against the real package
- Use an `ast.NodeVisitor` instead of a for loop.
- Add tests for the node visitor