### PR TITLE
Don't error on Syntax error

### DIFF
--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -44,6 +44,13 @@ def strip_magic(code: str) -> str:
     return code
 
 
+def try_parse_ast(code: str) -> ast.AST | None:
+    try:
+        return ast.parse(code)
+    except (SyntaxError, IndentationError):
+        return None
+
+
 def capture_registered_calls(info: ExecutionInfo) -> None:
     """
     Use the AST module to parse the code that we are executing & send an API call
@@ -67,9 +74,8 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
 
     code = strip_magic(code)
 
-    try:
-        tree = ast.parse(code)
-    except (SyntaxError, IndentationError):
+    tree = try_parse_ast(code)
+    if tree is None:
         return None
 
     user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -44,13 +44,6 @@ def strip_magic(code: str) -> str:
     return code
 
 
-def try_parse_ast(code: str) -> ast.AST | None:
-    try:
-        return ast.parse(code)
-    except (SyntaxError, IndentationError):
-        return None
-
-
 def capture_registered_calls(info: ExecutionInfo) -> None:
     """
     Use the AST module to parse the code that we are executing & send an API call
@@ -74,8 +67,9 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
 
     code = strip_magic(code)
 
-    tree = try_parse_ast(code)
-    if tree is None:
+    try:
+        tree = ast.parse(code)
+    except (SyntaxError, IndentationError):
         return None
 
     user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -35,7 +35,7 @@ def strip_magic(code: str) -> str:
 
     """
 
-    IPYTHON_MAGIC_PATTERN = r"^\s*[%!?]{1,2}|^.*\?\?$"
+    IPYTHON_MAGIC_PATTERN = r"^\s*[%!?]{1,2}|^.*\?{1,2}$"
 
     code = "\n".join(
         line for line in code.splitlines() if not re.match(IPYTHON_MAGIC_PATTERN, line)
@@ -48,6 +48,8 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
     """
     Use the AST module to parse the code that we are executing & send an API call
     if we detect specific function or method calls.
+
+    Fail silently if we can't parse the code.
 
     Parameters
     ----------
@@ -65,7 +67,10 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
 
     code = strip_magic(code)
 
-    tree = ast.parse(code)
+    try:
+        tree = ast.parse(code)
+    except (SyntaxError, IndentationError):
+        return None
 
     user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -453,6 +453,8 @@ class MyClass:
 MyClass.func(instance)
 
 MyClass.func??
+
+MyClass.func?
     """
 
     python_code = r"""
@@ -465,6 +467,7 @@ class MyClass:
         pass
 
 MyClass.func(instance)
+
 
     """
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -6,7 +6,7 @@
 import ast
 import sys
 import pytest
-from access_py_telemetry.ast import CallListener, strip_magic
+from access_py_telemetry.ast import CallListener, strip_magic, capture_registered_calls
 from unittest.mock import MagicMock
 
 
@@ -479,3 +479,43 @@ MyClass.func(instance)
     a = ast.dump(ast.parse(parsed_w_magic), annotate_fields=False)
     b = ast.dump(ast.parse(parsed_wo_magic), annotate_fields=False)
     assert a == b
+
+
+def test_parse_invalid_code():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    def func(self):
+        self.set_var = set()
+
+    def uncaught_func(self, *args, **kwargs):
+        pass
+
+instance = MyClass()
+mycall = instance.func()
+
+    instance.uncaught_func()
+
+
+"""
+
+    capture_registered_calls(mock_info)
+
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+class MyClass:
+    def func(self):
+        self.set_var = set()
+
+    def uncaught_func(self, *args, **kwargs):
+        pass
+
+@instance = MyClass()
+1mycall = instance.func()
+
+    instance.uncaught_func()
+
+
+"""
+
+    capture_registered_calls(mock_info)


### PR DESCRIPTION
- Use try/catch in AST Parser, silently fail on a syntax error rather than raising.
- Allow `func?` in code blocks (Ipython magic).