### PR TITLE
Remove implicit boolean conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest-httpserver", # #Endpoints for testing.
     "intake",
     "access-nri-intake",
+    "numpy",
 ]
 
 [project.scripts]

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -74,8 +74,13 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
 
     user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore
 
-    visitor = CallListener(user_namespace, REGISTRIES, api_handler)
-    visitor.visit(tree)
+    try:
+        visitor = CallListener(user_namespace, REGISTRIES, api_handler)
+        visitor.visit(tree)
+    except Exception:
+        # Catch all exceptions to avoid breaking the execution
+        # of the code being run.
+        return None
 
     return None
 
@@ -132,7 +137,7 @@ class CallListener(ast.NodeVisitor):
             else:
                 # Check if the first part is in the user namespace
                 instance = self.user_namespace.get(parts[0])
-                if not instance:
+                if instance is None:
                     self.generic_visit(node)
                     return None
 
@@ -169,7 +174,7 @@ class CallListener(ast.NodeVisitor):
         if full_name:
             parts = full_name.split(".")
             instance = self.user_namespace.get(parts[0])
-            if not instance:
+            if instance is None:
                 return None
 
             class_name = type(instance).__name__

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -519,3 +519,32 @@ class MyClass:
 """
 
     capture_registered_calls(mock_info)
+
+
+def test_implicit_boolean_conversion():
+    mock_info = MockInfo()
+    mock_info.raw_cell = """
+
+import numpy as np
+
+arr = np.array([0, 2, 3])
+
+arr.mean()
+
+"""
+
+    f = sys._getframe()
+    exec(mock_info.raw_cell, globals(), f.f_locals)
+    mock_user_ns = f.f_locals
+
+    mock_registry = {"mock": ["ndarray.mean"]}
+
+    mock_api_handler = MagicMock()
+
+    tree = ast.parse(mock_info.raw_cell)
+
+    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
+
+    visitor.visit(tree)
+
+    assert visitor._caught_calls == {"ndarray.mean"}


### PR DESCRIPTION
See [forum post](https://forum.access-hive.org.au/t/strange-error-using-xp65/4444)

Also added a catchall try/except to prevent further issues.