### PR TITLE
refactor(api): drop unused config load

### DIFF
--- a/src/access_py_telemetry/api.py
+++ b/src/access_py_telemetry/api.py
@@ -13,12 +13,11 @@ import sys
 import uuid
 import warnings
 from functools import wraps
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any, Callable, Iterable, Type
 
 import httpx
 import pydantic
-import yaml
 
 from .utils import ENDPOINTS
 
@@ -28,9 +27,6 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
-
-with open(Path(__file__).parent / "config.yaml", "r") as f:
-    config = yaml.safe_load(f)
 
 NRI_USER = True
 


### PR DESCRIPTION
**Stack 1/4** — base: `main`

`api.py` loaded and parsed `config.yaml` into a module-level `config` that nothing referenced. This removes the dead load along with the now-unused `yaml` and `pathlib.Path` imports (`PurePosixPath` is still used).

Pure cleanup, no behaviour change. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)