### PR TITLE
feat(config): add typed-transition table for call detection

### DIFF
--- a/src/access_py_telemetry/config.yaml
+++ b/src/access_py_telemetry/config.yaml
@@ -1,8 +1,13 @@
 # Telemetry configuration.
 #
+# Two sections:
 #   registries:  the registered call names, grouped by service. This is the source
 #                of truth for ENDPOINTS / REGISTRIES (see utils.py) and is walked by
-#                build_endpoints.
+#                build_endpoints exactly as the whole file used to be.
+#   transitions: the type-flow knowledge the AST interpreter uses to resolve chained
+#                calls (see ast.py). A registered method's successor node type defaults
+#                to *self* (the same node), so only type-*changing* edges and the
+#                generators that mint a node from a module path / factory are listed here.
 
 registries:
   intake:
@@ -59,3 +64,21 @@ registries:
       - metadata_validate
       - metadata_template
       - use_esm_datatore
+
+transitions:
+  # Source patterns that mint a node from a module path or factory function.
+  # (Constructors `ClassName(...)` are handled implicitly by the interpreter and
+  # need no entry here.)
+  generators:
+    intake.cat.access_nri: DfFileCatalog
+    open_esm_datastore: esm_datastore
+
+  # Method edges that CHANGE the node type. Anything registered but not listed here
+  # defaults to returning *self*, which is correct for `.search(...)` chains and
+  # harmless for terminal methods (`.to_dask()` etc.) whose result carries no
+  # registered methods.
+  overrides:
+    DfFileCatalog:
+      __getitem__: esm_datastore
+    AliasedDataframeCatalog:
+      __getitem__: AliasedESMCatalog

--- a/src/access_py_telemetry/utils.py
+++ b/src/access_py_telemetry/utils.py
@@ -50,3 +50,13 @@ REGISTRIES = {
     register.endpoint.replace("/", "_"): register.items
     for register in build_endpoints(config["registries"])
 }
+
+# Type-flow knowledge used by the AST interpreter (see ast.py). See config.yaml for
+# the semantics: GENERATORS mint a node from a module path / factory function, and
+# TYPE_OVERRIDES record the method edges that *change* node type (everything else
+# defaults to returning self).
+_transitions: dict[str, Any] = config.get("transitions", {}) or {}
+
+GENERATORS: dict[str, str] = _transitions.get("generators", {}) or {}
+
+TYPE_OVERRIDES: dict[str, dict[str, str]] = _transitions.get("overrides", {}) or {}


### PR DESCRIPTION
**Stack 3/4** — base: `telemetry/config-nest-registries` (#99)

Introduces a `transitions:` section in `config.yaml` plus matching `GENERATORS` / `TYPE_OVERRIDES` exports in `utils.py`, describing the type flow the AST interpreter needs to resolve chained calls:

- **generators** mint a node type from a module path / factory (`intake.cat.access_nri -> DfFileCatalog`, `open_esm_datastore -> esm_datastore`);
- **overrides** record only the method edges that *change* node type (the catalog `__getitem__` -> datastore edges) — a registered method's successor type otherwise defaults to *self*.

Data only; the interpreter that consumes it lands in #4 of the stack. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)