### PR TITLE
feat(ast): detect calls with a typed-transition interpreter

### DIFF
--- a/plans/telemetry-transition-ir.md
+++ b/plans/telemetry-transition-ir.md
@@ -1,0 +1,255 @@
+# Telemetry call-detection rewrite — typed transition IR
+
+**Status:** IN PROGRESS. Core implemented, full suite (71) green, lint + mypy clean,
+`api.py` dead-config removed. Remaining: real `access-nri-intake` chain sanity-check,
+then commit. See "Progress — resume here" at the bottom.
+
+---
+
+## Context — why we're changing this
+
+`src/access_py_telemetry/ast.py` hooks IPython (`pre_run_cell`) and, for each executed
+cell, detects which *registered* function/method calls occur so it can POST telemetry.
+The registry (`config.yaml`) is written in **type-qualified** names (`esm_datastore.search`,
+`DfFileCatalog.__getitem__`, `intake.cat.access_nri`), but user source uses **variables**
+(`esm_ds.search(...)`, `cat[...]`). Bridging `esm_ds → esm_datastore` is the whole problem.
+
+The current implementation bridges it by consulting the **live IPython namespace**
+(`ChainSimplifier._resolve_type` does `type(instance).__name__`) and even `eval`ing
+subscript expressions. This has two structural problems:
+
+1. **It breaks on same-cell instantiation.** `pre_run_cell` fires *before* the cell runs,
+   so an object created in the current cell doesn't exist in `user_ns` yet and can't be
+   typed. This is the motivating bug (documented in `test_notebooks/ast_debugger.ipynb`).
+   The existing `test_ast.py` masks it: every test `exec`s the cell into the namespace
+   *before* running the visitors, a state production never sees.
+2. **It's hard to maintain.** Two passes (`ChainSimplifier` rewrites the CST in place,
+   then `CallListener` re-walks it), a large `extract_call_args_kwargs` match statement,
+   an `eval`, and hardcoded special-cases (e.g. the `intake.cat.access_nri` arm).
+
+## The idea — a domain-specific typed transition IR
+
+Model detection as a **typed transition system** (abstract interpretation where the
+abstract domain is our *own telemetry node types*, not Python types). Equivalently: a
+finite-state machine where registered calls are emitting edges.
+
+- **States = node kinds:** `DfFileCatalogNode`, `EsmCatNode`, … decoupled from real classes.
+- **Generators:** source patterns that mint a node from root — `intake.cat.access_nri →
+  DfFileCatalogNode`, `open_esm_datastore(...) → EsmCatNode`, `esm_datastore(...) →
+  EsmCatNode` (constructor).
+- **Transitions:** a call `receiver.method(...)` is an edge `T --method--> T'` that
+  **emits** a telemetry event and yields successor state `T'`.
+- **Bindings:** `name = <expr>` binds `name` to the node type `<expr>` evaluates to, in an
+  environment. Because binding is syntactic, **same-cell instantiation just works** — no
+  namespace, no `eval`. A single forward, evaluation-order walk emits events **in source
+  order** for free (the current two-pass design has to `|=` the two result sets).
+
+`config.yaml` changes from a flat list of qualified strings into a **transition table**:
+
+```yaml
+generators:
+  intake.cat.access_nri: DfFileCatalogNode   # also emits (it's registered)
+  open_esm_datastore:    EsmCatNode
+  esm_datastore:         EsmCatNode           # constructor
+DfFileCatalogNode:
+  __getitem__: EsmCatNode
+  search:      DfFileCatalogNode
+EsmCatNode:
+  search:      self          # returns self
+  to_dask:     Dataset       # foreign/terminal node — no registered edges
+```
+
+All the knowledge currently smeared across `ChainSimplifier`'s special cases + the subscript
+`eval` (what `__getitem__` returns, "search returns self", the `intake.cat.access_nri`
+hardcode) becomes **data** in this table.
+
+### Worked example
+
+```python
+cat = intake.cat.access_nri          # generator → env[cat]=DfFileCatalogNode  (emit intake.cat.access_nri)
+esm_ds = cat["1deg_era5_iaf"]        # DfFileCatalogNode --__getitem__--> EsmCatNode  (emit DfFileCatalog.__getitem__)
+esm_ds.search(...).search(...).to_dask()
+#   EsmCatNode --search--> EsmCatNode --search--> EsmCatNode --to_dask--> Dataset
+#   emits esm_datastore.search, esm_datastore.search, esm_datastore.to_dask — in order
+```
+
+## Architecture
+
+Mirror xrexpr's discipline of **pure stages with I/O isolated to the end**:
+
+1. **Front-end (parse → lower):** keep **`libcst`** (unchanged dependency — deliberately not
+   switching to stdlib `ast`, to keep this PR focused). It walks the cell and lowers it into
+   the node interpreter, supplying only structure (call boundaries, arg groupings, chain
+   spine, assignment LHS/RHS) — the "recognize `intake.cat.access_nri` as a generator" logic
+   is *table lookups*, not lexing. **A raw lexer is rejected:** it discards paren/bracket
+   nesting the interpreter needs and would re-derive a parser badly. (A later PR could drop
+   libcst for stdlib `ast` now that we no longer rewrite the tree — noted, out of scope here.)
+2. **Interpreter (pure):** forward evaluation-order walk maintaining a **type environment**
+   (`name → node type`) and a **value environment** (`name → literal`, for args). It's a
+   pure function of `(seed_env, source)` returning `list[TelemetryEvent]` — *no*
+   `api_handler` calls mid-walk. Directly snapshot-testable ("seed + source → events") with
+   no mocking.
+2a. **Env seeding (confined namespace read):** before the walk, pre-scan the cell for the
+   free names it references, look those up in `user_ns`, and build a bounded seed env —
+   type via `type(obj).__name__` (module special-case for `import os as …`), value for
+   simple literals. Same-cell bindings then layer on top during the walk. This is the
+   *only* place `user_ns` is touched; it replaces `_resolve_type`'s mid-walk poking and the
+   subscript `eval`. See Q3 (resolved).
+3. **Dispatch (I/O):** thin layer turns events into `ApiHandler.send_api_request(service,
+   name, args, kwargs)` calls. Parse failure still routes raw code to
+   `send_failure_api_request(..., "intake/failed-telemetry", ...)` as today.
+
+### What this deletes / replaces
+
+- `ChainSimplifier` (CST-rewriting transformer) — gone; chains become state transitions.
+- `CallListener` (second visitor) — folded into the single interpreter pass.
+- `extract_call_args_kwargs`'s giant match — shrinks to literal/kwarg extraction feeding
+  the value environment.
+- The `eval` of subscripts and the mid-walk `user_ns` type resolution — gone; `user_ns` use
+  is confined to the one-time env seed (step 2a). Node types are just the class-name strings
+  already in `config.yaml`, so seeding is `type(obj).__name__`.
+
+### Reused / unchanged
+
+- `ApiHandler.send_api_request` / `send_failure_api_request` signatures (`api.py`).
+- `utils.build_endpoints` / `REGISTRIES` / `ENDPOINTS` machinery — but note the registry
+  *shape* changes (flat set → transition table); `build_endpoints` and consumers will need
+  to keep producing the `service_name → {emitted qualified names}` view the API layer wants,
+  derived from the new table.
+- `strip_magic`, the `pre_run_cell` registration in `__init__.py`.
+
+## Verification (once built)
+
+- New `tests/` that assert **cell source → ordered `list[TelemetryEvent]`** directly (no
+  `exec`, no MagicMock), including the same-cell-instantiation case from
+  `test_notebooks/ast_debugger.ipynb` that current tests can't express.
+- Port existing `test_ast.py` scenarios (chained calls, aliased module/function, string /
+  int / variable indexing, `intake.cat.access_nri` import+index+search, args/kwargs) onto
+  the new surface.
+- Confirm emit **ordering** matches the API's expectations (the `test_chained_function_call`
+  three-in-order case).
+
+## Implementation steps
+
+1. **Transition-table config.** Extend `config.yaml` with `generators:` and per-node
+   transition maps (successor node type per method; `self` / terminal markers). Preserve the
+   derived `service_name → {emitted qualified names}` view so `utils.build_endpoints`,
+   `REGISTRIES`, `ENDPOINTS` and the API layer keep working unchanged. Node types are the
+   class-name strings already used in the registry.
+2. **IR + event types.** Define `TelemetryEvent` (service-agnostic: qualified name, args,
+   kwargs) and the node-type/transition lookups loaded from config.
+3. **Env seeding.** A helper that, given the parsed cell and `user_ns`, collects free names
+   and builds the bounded seed env (type via `type(obj).__name__` + module special-case;
+   value for simple literals).
+4. **Interpreter.** A single libcst pass: forward, evaluation-order walk that maintains the
+   type + value environments, resolves each call/subscript/attribute receiver to a node
+   type, applies the transition table, and appends a `TelemetryEvent` on a match. Pure
+   `(seed_env, module) → list[TelemetryEvent]`. Absorbing `Unknown` node (Q1); straight-line
+   / last-write-wins control flow, disagreeing rebinds → `Unknown` (Q4).
+5. **Dispatch + wiring.** Replace `_run_tree`'s two-pass body with: seed → interpret →
+   dispatch each event via `ApiHandler.send_api_request`. Keep `strip_magic`, the parse-error
+   → `send_failure_api_request` path, and the `pre_run_cell` registration.
+6. **Delete** `ChainSimplifier`, `CallListener`, `extract_call_args_kwargs`'s rewrite
+   machinery, and the subscript `eval`.
+7. **Tests.** New pure `source → ordered events` tests (no `exec`, no MagicMock), including
+   the same-cell-instantiation case; port the existing `test_ast.py` scenarios onto the new
+   surface; assert emit ordering.
+
+## Decisions (resolved)
+
+- **Q1 — Unknown node.** Absorbing `Unknown` state, no outgoing edges; unregistered methods
+  or un-typeable receivers emit nothing (no false attribution). Bare functions are edges from
+  a root pseudo-state matched by bare name.
+- **Q2 — Value environment.** Seeds from the `user_ns` snapshot; same-cell literal bindings
+  layer on top. `cat[search_str]` resolves from an earlier cell (namespace) or a same-cell
+  `search_str='some_item'` (static). Dynamic/non-literal values left unresolved.
+- **Q3 — Cross-cell seeding.** Seed the env from a `user_ns` snapshot, then run the static
+  walk; **no** persisted cross-cell env. Namespace-independence isn't required
+  (`decorators.py` is the namespace-explicit lane; the AST module is IPython-only). Seeding
+  covers opaque births and avoids over-reporting from failed cells; the `pre_run_cell`
+  staleness only hit the same-cell case, which the static walk owns. Confined to the seed
+  step, so the interpreter stays pure.
+- **Q4 — Control flow.** v1 straight-line / last-write-wins; disagreeing branch rebinds
+  degrade to `Unknown` (refuse safely). Loop bodies walked once — detection holds (receiver
+  typed outside the loop); only per-iteration *counts* are lost, which telemetry doesn't
+  need. Full lattice join is future work.
+- **Front-end library.** Keep `libcst` for this PR (focused diff). Stdlib `ast` becomes a
+  viable follow-up now that tree-rewriting is gone.
+
+---
+
+## Progress — resume here
+
+**Branch:** `transition-ir`, stacked off `rewrite-via-lexer`. All work uncommitted
+(untracked `plans/`, modified `src/...config.yaml`, `src/...utils.py`, `src/...ast.py`,
+`tests/test_ast.py`). Nothing committed yet.
+
+### Done (implemented + passing)
+
+1. **`config.yaml`** restructured into `registries:` (old content verbatim, now nested)
+   + `transitions:` with `generators:` (`intake.cat.access_nri -> DfFileCatalog`,
+   `open_esm_datastore -> esm_datastore`) and `overrides:` (the two `__getitem__`
+   catalog->datastore edges). Successor type **defaults to self**, so only type-changing
+   edges are listed.
+2. **`utils.py`**: `build_endpoints(config["registries"])`; added `GENERATORS` and
+   `TYPE_OVERRIDES` exports. Verified `ENDPOINTS`/`REGISTRIES` keys + contents unchanged.
+3. **`ast.py`** fully rewritten as the typed-transition interpreter:
+   - Abstract values `Node` / `ClassRef` / `Dotted` / `UNKNOWN`; `TelemetryEvent`.
+   - `interpret(tree, registries, user_ns) -> list[TelemetryEvent]` (pure) via
+     `_Interpreter`; `_dispatch()` sends events through `ApiHandler.send_api_request`.
+   - `capture_registered_calls` = parse -> interpret -> dispatch, keeping `strip_magic`
+     and the parse-error -> `send_failure_api_request` path.
+   - Type resolution: source bindings (Import/ClassDef/FunctionDef/Assign) with **lazy
+     namespace fallback** in `_resolve_name` (an UNKNOWN RHS does *not* clobber a
+     namespace type — see `_bind_target`). Same-cell literals tracked in `_literals` for
+     arg resolution.
+   - Reused `extract_call_args_kwargs` (+ inner `_extract_dict_value`) verbatim for arg
+     extraction, passed a `ChainMap(_literals, user_ns)`.
+   - **Deleted** `ChainSimplifier`, `CallListener`, `_run_tree`, `_get_full_name`, and the
+     subscript `eval`.
+4. **`tests/test_ast.py`** rewritten to the `interpret` surface (asserts `source ->
+   events`, no `exec`/MagicMock). Added a real same-cell-instantiation test (no namespace).
+   Dropped the two `ChainSimplifier`-rewrite tests (rewriting no longer exists).
+   **29 passed** (see env note).
+
+### CRITICAL env gotcha (why tests looked like they imported stale code)
+
+- Plain `pixi run pytest` uses the **base-conda** interpreter with a **non-editable**
+  installed copy of the package (old code) — it shadows `src/`. The `test` feature also
+  installs the package `editable = false` (pyproject `[tool.pixi.feature.test.pypi-dependencies]`).
+- So to exercise the working tree you must put `src` first: **`PYTHONPATH=src pixi run ...`**
+  (what got 29/29), or reinstall, or flip that dep to `editable = true`.
+- The ast tests ran under base conda because they need no extra deps. The **full suite**
+  needs the `test` env (pytest_httpserver, numpy, pandas, intake, access-nri-intake).
+
+### Verification — DONE (2026-08-20)
+
+1. **Full suite green:** `PYTHONPATH=src pixi run -e test-py312 pytest --random-order tests`
+   → **71 passed**. `test_api.py`, `test_registry.py`, `test_decorators.py`, `test_cli.py`
+   all pass against the restructured `config.yaml`/`utils.py` (they consume
+   `REGISTRIES`/`ENDPOINTS`, unchanged).
+2. **Lint/type clean:** `ruff check` passes on `ast.py`/`utils.py`/`api.py`; `mypy ast.py`
+   → Success. Fixed one mypy+runtime bug: `Try.finalbody` is a `Finally` node, so the
+   finally body must be walked as `node.finalbody.body.body` (guarded by an
+   `isinstance(..., IndentedBlock)` check), not `node.finalbody.body`.
+3. **`api.py` cleanup done:** removed the dead `config = yaml.safe_load(...)` load and the
+   now-unused `yaml` / `pathlib.Path` imports (kept `PurePosixPath`). No `CHANGELOG.md` in
+   the repo, so nothing to add there.
+
+### Next steps
+
+1. **Sanity-check a real chain** against `access-nri-intake` in the test env (the actual
+   `intake.cat.access_nri[...].search(...).to_dask()` path) to confirm real class names
+   match the node-type strings in `config.yaml` (`DfFileCatalog`, `esm_datastore`, and the
+   `Aliased*` variants). Not yet done.
+2. Commit on `transition-ir`; open PR stacked on `rewrite-via-lexer` when ready.
+
+### Watch-outs / known limits (by design, see Decisions)
+
+- Loop bodies are walked once (detection holds, per-iteration counts don't) and disagreeing
+  branch rebinds degrade to `UNKNOWN`. Method/def bodies are also walked (parity with the
+  old libcst "visit everything"), which can bind method-local names into `type_env` — an
+  accepted v1 looseness.
+- Arg representation intentionally matches the *old* behaviour exactly: literal args/kwargs
+  are the verbatim source token (quotes included, e.g. `"'xyz'"`), `Name` args are resolved
+  from the value env to real objects, dict args are stripped via `_extract_dict_value`.

--- a/src/access_py_telemetry/ast.py
+++ b/src/access_py_telemetry/ast.py
@@ -2,10 +2,32 @@
 """
 Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 SPDX-License-Identifier: Apache-2.0
+
+Detect registered function / method calls in an IPython cell and emit telemetry.
+
+The registry (``config.yaml``) is written in *type-qualified* names
+(``esm_datastore.search``, ``DfFileCatalog.__getitem__``) but user source uses
+*variables* (``esm_ds.search(...)``). We bridge that gap with a small
+**typed transition interpreter**: the abstract domain is our own telemetry node
+types (the class-name strings in the registry), registered calls are edges that
+emit a :class:`TelemetryEvent` and yield a successor node type, and a binding
+environment carries types through assignments. A registered method's successor
+defaults to *self*; only type-*changing* edges and the module/factory
+*generators* are declared in ``config.yaml`` (see ``utils.GENERATORS`` /
+``utils.TYPE_OVERRIDES``).
+
+The interpreter is a pure function of ``(source, registries, user_ns)`` returning
+an ordered ``list[TelemetryEvent]``; dispatch to the API is a separate step. The
+live namespace is consulted only as a *fallback* when a receiver's type cannot be
+resolved from the cell's own source, which is what lets us type objects created in
+the same cell (the ``pre_run_cell`` hook fires before the cell has executed).
 """
 
+import ast as _pyast
 import re
-from typing import Any
+from collections import ChainMap
+from dataclasses import dataclass, field
+from typing import Any, Sequence, Union
 
 import libcst as cst
 from IPython.core.getipython import get_ipython
@@ -13,28 +35,69 @@ from IPython.core.interactiveshell import ExecutionInfo
 from libcst._exceptions import ParserSyntaxError
 
 from .api import ApiHandler
-from .registry import TelemetryRegister
-from .utils import REGISTRIES
+from .utils import GENERATORS, REGISTRIES, TYPE_OVERRIDES
 
 api_handler = ApiHandler()
 
-registries = {registry: TelemetryRegister(registry) for registry in REGISTRIES.keys()}
+
+# --------------------------------------------------------------------------- #
+# Abstract values — what an expression evaluates to during interpretation.
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class Node:
+    """A modelled *instance* of node type ``type_name`` (a class-name string)."""
+
+    type_name: str
+
+
+@dataclass(frozen=True)
+class ClassRef:
+    """A reference to a class ``name``; calling it yields ``Node(name)``."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class Dotted:
+    """A module / attribute dotted path, or a bare callable name (``os.path``)."""
+
+    path: str
+
+
+class _Unknown:
+    """The absorbing ⊤: an un-typeable value. Emits nothing, absorbs every edge."""
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return "UNKNOWN"
+
+
+UNKNOWN = _Unknown()
+
+AbstractValue = Union[Node, ClassRef, Dotted, _Unknown]
+
+
+@dataclass
+class TelemetryEvent:
+    """One detected registered call: the qualified name plus its verbatim args."""
+
+    name: str
+    args: list[Any] = field(default_factory=list)
+    kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 def strip_magic(code: str) -> str:
     """
-    Parse the provided code into an AST (Abstract Syntax Tree).
+    Remove IPython magic commands from a cell so it parses as plain Python.
 
     Parameters
     ----------
-
     code : str
         The code to parse.
+
     Returns
     -------
     str
         The code without IPython magic commands.
-
     """
 
     IPYTHON_MAGIC_PATTERN = r"^\s*[%!?]{1,2}|^.*\?{1,2}$"
@@ -48,10 +111,10 @@ def strip_magic(code: str) -> str:
 
 def capture_registered_calls(info: ExecutionInfo) -> None:
     """
-    Use the AST module to parse the code that we are executing & send an API call
-    if we detect specific function or method calls.
+    Parse the executing cell, detect registered calls, and dispatch telemetry.
 
-    Fail silently if we can't parse the code.
+    Fails silently (routing the raw code to the ``failed-telemetry`` endpoint) if
+    we can't parse or interpret the code, so telemetry never breaks a user's cell.
 
     Parameters
     ----------
@@ -77,31 +140,407 @@ def capture_registered_calls(info: ExecutionInfo) -> None:
         )
         return None
 
-    _run_tree(tree)
-
-    return None
-
-
-def _run_tree(tree: cst.Module) -> None:  # pragma: no cover
-    user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore
-
     try:
-        reducer = ChainSimplifier(user_namespace, REGISTRIES, api_handler)
-        reduced_tree = tree.visit(reducer)
-        visitor = CallListener(user_namespace, REGISTRIES, api_handler)
-        wrapper = cst.MetadataWrapper(reduced_tree)
-        wrapper.visit(visitor)
-        visitor._caught_calls |= reducer._caught_calls
+        user_namespace: dict[str, Any] = get_ipython().user_ns  # type: ignore
+        events = interpret(tree, REGISTRIES, user_namespace)
+        _dispatch(events, REGISTRIES)
     except Exception:
-        # Catch all exceptions to avoid breaking the execution
-        # of the code being run. Then post the raw code to the `failed-telemetry` endpoint
+        # Catch all exceptions to avoid breaking the execution of the code being
+        # run, then post the raw code to the `failed-telemetry` endpoint.
         api_handler.send_failure_api_request(
             "intake/failed-telemetry", tree.code, "intake/failed-telemetry"
         )
 
+    return None
+
+
+def interpret(
+    tree: cst.Module,
+    registries: dict[str, set[str]],
+    user_ns: dict[str, Any],
+) -> list[TelemetryEvent]:
+    """
+    Interpret a parsed cell into an ordered list of telemetry events.
+
+    A pure function of its inputs: no I/O, no namespace mutation. This is the unit
+    the tests drive directly (``source -> events``).
+
+    Parameters
+    ----------
+    tree : libcst.Module
+        The parsed cell.
+    registries : dict[str, set[str]]
+        Service name -> set of registered qualified names.
+    user_ns : dict[str, Any]
+        The live namespace, consulted only as a type/value fallback.
+
+    Returns
+    -------
+    list[TelemetryEvent]
+        The detected registered calls, in source (evaluation) order.
+    """
+    return _Interpreter(registries, user_ns).run(tree)
+
+
+def _dispatch(events: list[TelemetryEvent], registries: dict[str, set[str]]) -> None:
+    """Send each event to every service whose registry contains its name."""
+    for event in events:
+        for service, registered in registries.items():
+            if event.name in registered:
+                api_handler.send_api_request(
+                    service, event.name, event.args, event.kwargs
+                )
+
+
+class _Interpreter:
+    """Forward, evaluation-order walk that resolves receiver types and emits events."""
+
+    def __init__(
+        self, registries: dict[str, set[str]], user_ns: dict[str, Any]
+    ) -> None:
+        self.registered: set[str] = (
+            set().union(*registries.values()) if registries else set()
+        )
+        self.user_ns = user_ns
+        # Same-cell literal bindings, layered over the live namespace for arg
+        # resolution (extract_call_args_kwargs looks names up in this mapping).
+        self._literals: dict[str, Any] = {}
+        self.value_env: ChainMap[str, Any] = ChainMap(self._literals, user_ns)
+        # Concrete source-derived type bindings. A name absent here falls back to
+        # its runtime type in the namespace (see ``_resolve_name``).
+        self.type_env: dict[str, AbstractValue] = {}
+        self.events: list[TelemetryEvent] = []
+
+    # -- entry ------------------------------------------------------------- #
+    def run(self, tree: cst.Module) -> list[TelemetryEvent]:
+        self._walk(tree.body)
+        return self.events
+
+    # -- statement walk ---------------------------------------------------- #
+    def _walk(self, body: Sequence[cst.CSTNode]) -> None:
+        for stmt in body:
+            self._statement(stmt)
+
+    def _statement(self, stmt: cst.CSTNode) -> None:
+        match stmt:
+            case cst.SimpleStatementLine(body=small):
+                for small_stmt in small:
+                    self._small_statement(small_stmt)
+            case cst.ClassDef(name=cst.Name(value=name), body=cst.IndentedBlock() as b):
+                self.type_env[name] = ClassRef(name)
+                self._walk(b.body)
+            case cst.FunctionDef(
+                name=cst.Name(value=name), body=cst.IndentedBlock() as b
+            ):
+                # A bare callable ref: calling it emits by its (literal) name.
+                self.type_env[name] = Dotted(name)
+                self._walk(b.body)
+            case cst.If(body=cst.IndentedBlock() as b, orelse=orelse):
+                self._walk(b.body)
+                self._orelse(orelse)
+            case cst.For(body=cst.IndentedBlock() as b, orelse=orelse):
+                self._walk(b.body)
+                self._orelse(orelse)
+            case cst.While(body=cst.IndentedBlock() as b, orelse=orelse):
+                self._walk(b.body)
+                self._orelse(orelse)
+            case cst.With(body=cst.IndentedBlock() as b):
+                self._walk(b.body)
+            case cst.Try() as node:
+                self._walk(node.body.body)
+                for handler in node.handlers:
+                    self._walk(handler.body.body)
+                self._orelse(node.orelse)
+                if node.finalbody is not None and isinstance(
+                    node.finalbody.body, cst.IndentedBlock
+                ):
+                    self._walk(node.finalbody.body.body)
+            case _:
+                pass
+
+    def _orelse(self, orelse: cst.CSTNode | None) -> None:
+        match orelse:
+            case cst.Else(body=cst.IndentedBlock() as b):
+                self._walk(b.body)
+            case cst.If():
+                self._statement(orelse)
+            case cst.Try():
+                self._statement(orelse)
+            case _:
+                pass
+
+    def _small_statement(self, stmt: cst.CSTNode) -> None:
+        match stmt:
+            case cst.Import(names=names):
+                for alias in names:
+                    self._bind_import(alias)
+            case cst.ImportFrom(names=names) if not isinstance(names, cst.ImportStar):
+                for alias in names:
+                    self._bind_import_from(alias)
+            case cst.Assign(targets=targets, value=value):
+                resolved = self._eval(value)
+                self._capture_literal(targets, value)
+                for target in targets:
+                    self._bind_target(target.target, resolved)
+            case cst.AnnAssign(target=target, value=value) if value is not None:
+                resolved = self._eval(value)
+                self._bind_target(target, resolved)
+            case cst.Expr(value=value):
+                self._eval(value)
+            case cst.Return(value=value) if value is not None:
+                self._eval(value)
+            case _:
+                pass
+
+    # -- bindings ---------------------------------------------------------- #
+    def _bind_import(self, alias: cst.ImportAlias) -> None:
+        module = _dotted_name(alias.name)
+        if module is None:
+            return
+        if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
+            self.type_env[alias.asname.name.value] = Dotted(module)
+        else:
+            # `import a.b.c` binds the top-level name `a`.
+            self.type_env[module.split(".")[0]] = Dotted(module.split(".")[0])
+
+    def _bind_import_from(self, alias: cst.ImportAlias) -> None:
+        name = _dotted_name(alias.name)
+        if name is None:
+            return
+        if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
+            self.type_env[alias.asname.name.value] = Dotted(name)
+        else:
+            self.type_env[name] = Dotted(name)
+
+    def _bind_target(self, target: cst.CSTNode, value: AbstractValue) -> None:
+        if not isinstance(target, cst.Name):
+            return
+        if isinstance(value, _Unknown):
+            # Don't clobber a namespace-derived type with an un-typeable RHS; drop
+            # the source binding so `_resolve_name` falls back to the namespace.
+            self.type_env.pop(target.value, None)
+        else:
+            self.type_env[target.value] = value
+
+    def _capture_literal(
+        self, targets: Sequence[cst.AssignTarget], value: cst.BaseExpression
+    ) -> None:
+        """Record a same-cell literal binding for later arg resolution."""
+        literal = _literal_value(value)
+        if literal is _NO_LITERAL:
+            return
+        for target in targets:
+            if isinstance(target.target, cst.Name):
+                self._literals[target.target.value] = literal
+
+    # -- expression evaluation -------------------------------------------- #
+    def _eval(self, node: cst.BaseExpression) -> AbstractValue:
+        match node:
+            case cst.Name(value=name):
+                return self._resolve_name(name)
+            case cst.Attribute(value=base, attr=cst.Name(value=attr)):
+                return self._attribute(self._eval(base), attr, emit=True)
+            case cst.Call():
+                return self._call(node)
+            case cst.Subscript():
+                return self._subscript(node)
+            case cst.List():
+                return Node("list")
+            case cst.Tuple():
+                return Node("tuple")
+            case cst.Dict():
+                return Node("dict")
+            case cst.Set():
+                return Node("set")
+            case _:
+                return UNKNOWN
+
+    def _resolve_name(self, name: str) -> AbstractValue:
+        if name in self.type_env:
+            return self.type_env[name]
+        if name in self.user_ns:
+            return _abstract_from_obj(self.user_ns[name])
+        return UNKNOWN
+
+    def _attribute(
+        self, base: AbstractValue, attr: str, *, emit: bool
+    ) -> AbstractValue:
+        """Attribute access ``base.attr``. Emits (when ``emit``) if registered."""
+        match base:
+            case Node(type_name=tname) | ClassRef(name=tname):
+                qualname = f"{tname}.{attr}"
+                if emit:
+                    self._maybe_emit(qualname, [], {})
+                return self._method_successor(tname, attr)
+            case Dotted(path=path):
+                newpath = f"{path}.{attr}"
+                if emit:
+                    self._maybe_emit(newpath, [], {})
+                if newpath in GENERATORS:
+                    return Node(GENERATORS[newpath])
+                return Dotted(newpath)
+            case _:
+                return UNKNOWN
+
+    def _call(self, node: cst.Call) -> AbstractValue:
+        # Evaluate arguments first, for side-effect emits from nested calls.
+        for arg in node.args:
+            self._eval(arg.value)
+
+        match node.func:
+            case cst.Attribute(value=base, attr=cst.Name(value=attr)):
+                receiver = self._eval(base)
+                return self._call_method(receiver, attr, node)
+            case cst.Name(value=name):
+                return self._call_name(name, node)
+            case _:
+                self._eval(node.func)
+                return UNKNOWN
+
+    def _call_name(self, name: str, node: cst.Call) -> AbstractValue:
+        callee = self._resolve_name(name)
+        match callee:
+            case ClassRef(name=cls):
+                # Constructor: `MyClass(...)` -> Node("MyClass").
+                self._maybe_emit_call(cls, node)
+                return Node(cls)
+            case Dotted(path=path):
+                self._maybe_emit_call(path, node)
+                if path in GENERATORS:
+                    return Node(GENERATORS[path])
+                return UNKNOWN
+            case _:
+                # Fall back to the literal name (matches bare-function detection).
+                self._maybe_emit_call(name, node)
+                if name in GENERATORS:
+                    return Node(GENERATORS[name])
+                return UNKNOWN
+
+    def _call_method(
+        self, receiver: AbstractValue, attr: str, node: cst.Call
+    ) -> AbstractValue:
+        match receiver:
+            case Node(type_name=tname) | ClassRef(name=tname):
+                self._maybe_emit_call(f"{tname}.{attr}", node)
+                return self._method_successor(tname, attr)
+            case Dotted(path=path):
+                self._maybe_emit_call(f"{path}.{attr}", node)
+                return UNKNOWN
+            case _:
+                return UNKNOWN
+
+    def _subscript(self, node: cst.Subscript) -> AbstractValue:
+        base = self._eval(node.value)
+        tname: str | None = None
+        match base:
+            case Node(type_name=name) | ClassRef(name=name):
+                tname = name
+            case _:
+                tname = None
+        if tname is None:
+            return UNKNOWN
+
+        args = self._subscript_args(node)
+        self._maybe_emit(f"{tname}.__getitem__", args, {})
+        return self._method_successor(tname, "__getitem__")
+
+    # -- transition table -------------------------------------------------- #
+    def _method_successor(self, type_name: str, method: str) -> AbstractValue:
+        """Successor node type of ``type_name.method`` (default: self)."""
+        override = TYPE_OVERRIDES.get(type_name, {}).get(method)
+        if override is not None:
+            return Node(override)
+        if f"{type_name}.{method}" in self.registered:
+            return Node(type_name)  # default: returns self
+        return UNKNOWN
+
+    # -- emission ---------------------------------------------------------- #
+    def _maybe_emit(
+        self, qualname: str, args: list[Any], kwargs: dict[str, Any]
+    ) -> None:
+        if qualname in self.registered:
+            self.events.append(TelemetryEvent(qualname, args, kwargs))
+
+    def _maybe_emit_call(self, qualname: str, node: cst.Call) -> None:
+        if qualname in self.registered:
+            args, kwargs = extract_call_args_kwargs(node, self.value_env)
+            self.events.append(TelemetryEvent(qualname, args, kwargs))
+
+    def _subscript_args(self, node: cst.Subscript) -> list[Any]:
+        if len(node.slice) != 1:
+            return []
+        index = node.slice[0].slice
+        if not isinstance(index, cst.Index):
+            return []
+        match index.value:
+            case (
+                cst.SimpleString(value=val)
+                | cst.Integer(value=val)
+                | cst.Float(value=val)
+            ):
+                return [val]
+            case cst.Name(value=name):
+                resolved = self.value_env.get(name, _NO_LITERAL)
+                if resolved is _NO_LITERAL:
+                    return []
+                if isinstance(resolved, int) and not isinstance(resolved, bool):
+                    return [f"{resolved}"]
+                return [f"'{resolved}'"]
+            case _:
+                return []
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _abstract_from_obj(obj: Any) -> AbstractValue:
+    """Type a live namespace object into an abstract value."""
+    import types
+
+    if isinstance(obj, types.ModuleType):
+        return Dotted(getattr(obj, "__name__", ""))
+    if isinstance(obj, type):
+        return ClassRef(obj.__name__)
+    return Node(type(obj).__name__)
+
+
+def _dotted_name(node: cst.CSTNode) -> str | None:
+    """Flatten an import name (``Name`` / dotted ``Attribute``) into ``a.b.c``."""
+    match node:
+        case cst.Name(value=str() as name):
+            return name
+        case cst.Attribute(value=base, attr=cst.Name(value=attr)):
+            base_name = _dotted_name(base)
+            return f"{base_name}.{attr}" if base_name is not None else None
+        case _:
+            return None
+
+
+class _NoLiteral:
+    pass
+
+
+_NO_LITERAL = _NoLiteral()
+
+
+def _literal_value(node: cst.BaseExpression) -> Any:
+    """Best-effort Python value of a literal expression, else ``_NO_LITERAL``."""
+    match node:
+        case cst.SimpleString(value=val):
+            try:
+                return _pyast.literal_eval(val)
+            except (ValueError, SyntaxError):  # pragma: no cover
+                return _NO_LITERAL
+        case cst.Integer(value=val):
+            return int(val)
+        case cst.Float(value=val):
+            return float(val)
+        case _:
+            return _NO_LITERAL
+
 
 def extract_call_args_kwargs(
-    node: cst.Call, user_ns: dict[str, Any]
+    node: cst.Call, user_ns: Any
 ) -> tuple[list[Any], dict[str, Any]]:  # pragma: no cover
     """
     Take a cst Call Node and extract the args and kwargs, into a tuple of (args, kwargs)
@@ -203,379 +642,3 @@ def extract_call_args_kwargs(
                 return args, kwargs
 
     return args, kwargs
-
-
-class CallListener(cst.CSTVisitor):
-    METADATA_DEPENDENCIES = (cst.metadata.ParentNodeProvider,)
-
-    def __init__(
-        self,
-        user_namespace: dict[str, Any],
-        registries: dict[str, set[str]],
-        api_handler: ApiHandler,
-    ):
-        self.user_namespace = user_namespace
-        self.registries = registries
-        self._caught_calls: set[str] = set()  # Mostly for debugging
-        self.api_handler = api_handler
-
-    def visit_Attribute(self, node: cst.Attribute) -> None:
-        parent = self.get_metadata(cst.metadata.ParentNodeProvider, node)
-        full_name = self._get_full_name(node)
-        match full_name, parent:
-            case str(), cst.Call():
-                return None
-            case str(), _:
-                self._process_api_call(full_name, [], {})
-        return None
-
-    def visit_Call(self, node: cst.Call) -> None:
-        """
-        Visit a call node, process it if it's a registered call
-        """
-        match node:
-            case cst.Call(
-                func=cst.Name(
-                    value=full_name,
-                )
-            ):
-                args, kwargs = extract_call_args_kwargs(node, self.user_namespace)
-                self._process_api_call(full_name, args, kwargs)
-            case cst.Call(
-                func=cst.Attribute(
-                    value=cst.Name(value=base_name),
-                    attr=cst.Name(
-                        value=attr_name,
-                    ),
-                )
-            ):
-                args, kwargs = extract_call_args_kwargs(node, self.user_namespace)
-                full_name = f"{base_name}.{attr_name}"
-                self._process_api_call(full_name, args, kwargs)
-            case cst.Call(func=cst.Attribute() as attr_node):
-                if full_name := self._get_full_name(attr_node):
-                    # If we have a full name, we can process the call
-                    args, kwargs = extract_call_args_kwargs(node, self.user_namespace)
-                    self._process_api_call(full_name, args, kwargs)
-
-    def _process_api_call(
-        self, func_name: str, args: list[Any], kwargs: dict[str, Any]
-    ) -> None:
-        """Process an API call for a matched function name."""
-        for registry, registered_funcs in self.registries.items():
-            if func_name in registered_funcs:
-                self.api_handler.send_api_request(
-                    registry,
-                    func_name,
-                    args,
-                    kwargs,
-                )
-                self._caught_calls |= {func_name}
-
-    def _get_full_name(self, node: cst.CSTNode) -> str:
-        """Recursively get the full name of a function or method call."""
-        return _get_full_name(node)
-
-
-class ChainSimplifier(cst.CSTTransformer):
-    """
-    Transform chained calls by removing intermediate method calls
-    Example: ds.search(...).search(...).to_dataset_dict()
-    becomes: ds.to_dataset_dict()
-    """
-
-    def __init__(
-        self,
-        user_namespace: dict[str, Any],
-        registries: dict[str, set[str]],
-        api_handler: ApiHandler,
-    ):
-        self.user_namespace = user_namespace
-        self.registries = registries
-        self._caught_calls: set[str] = set()  # Mostly for debugging
-        self.api_handler = api_handler
-        self._inferred_types: dict[str, str] = {}
-
-    def _resolve_type(self, instance_name: str) -> str:
-        """
-        Resolve the type of an instance by its name.
-        If the instance is a module, return its name.
-        """
-        instance = self.user_namespace.get(instance_name)
-        if instance is None:
-            return self._inferred_types.get(instance_name, "type")
-        type_name = type(instance).__name__
-        if type_name == "module":
-            type_name = getattr(instance, "__name__", instance_name)
-        return type_name
-
-    def leave_Assign(
-        self, original_node: cst.Assign, updated_node: cst.Assign
-    ) -> cst.Assign:
-        """
-        When we leave an assignment node, if the value is a call to a registered
-        function, we infer the type of the variable being assigned to.  We also
-        handle the case of assigning a variable to another variable, so we can
-        track type information through simple variable assignments.  This allows
-        us to resolve the type of variables that are assigned from API calls, and
-        use that type information to simplify chained calls.
-        """
-        match updated_node:
-            case cst.Assign(
-                targets=[cst.AssignTarget(target=cst.Name(value=var_name))],
-                value=cst.Name(value=type_name),
-            ):
-                self._inferred_types[var_name] = type_name
-            case _:
-                pass
-        return updated_node
-
-    def leave_Attribute(
-        self, original_node: cst.Attribute, updated_node: cst.Attribute
-    ) -> cst.Attribute:
-        """
-        When we leave an attribute node, if it's parent is a cst.Name (ie. the
-        root of a chain of attribute accesses), we replace the value of the
-        attribute with the type name of the instance.
-        """
-
-        match updated_node:
-            case cst.Attribute(
-                value=cst.Name(
-                    value=instance_name,
-                ),
-                attr=cst.Name(value=_),
-            ) if (type_name := self._resolve_type(instance_name)) not in [None, "type"]:
-                return updated_node.with_changes(value=cst.Name(type_name))
-            case cst.Attribute(
-                value=cst.Call(
-                    func=cst.Name(
-                        value=_maybe_class_name,
-                    ),
-                )
-            ) if (
-                type(self.user_namespace.get(_maybe_class_name, None)) is type
-            ):
-                return updated_node.with_changes(value=cst.Name(_maybe_class_name))
-
-            case _:
-                return updated_node
-
-    def leave_Subscript(
-        self, original_node: cst.Subscript, updated_node: cst.Subscript
-    ) -> cst.Call | cst.Name:
-        """
-        When we leave a subscript node, replace eg. `instance[key]` with `ClassName.__getitem__(key)`.
-        This means there is no need for a `CallListener.visit_Subscript` method.
-        """
-        match updated_node:
-            case cst.Subscript(  # Something like MyClass()['key']
-                value=cst.Call(func=cst.Name(value=type_name)),
-                slice=[
-                    cst.SubscriptElement(
-                        slice=cst.Index(value=cst.SimpleString(value=args))
-                    )
-                ],
-            ) if (
-                type(self.user_namespace.get(type_name, None)) is type
-            ):
-                return self._process_subscript_call(type_name, updated_node, args)
-            case cst.Subscript(  # String index, eg. instance['key']
-                value=cst.Name(value=instance_name),
-                slice=[
-                    cst.SubscriptElement(
-                        slice=cst.Index(value=cst.SimpleString(value=args))
-                    )
-                ],
-            ) if (type_name := self._resolve_type(instance_name)) is not None:
-                return self._process_subscript_call(type_name, updated_node, args)
-
-            case cst.Subscript(  # Integer index
-                value=cst.Name(value=instance_name),
-                slice=[
-                    cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value=args)))
-                ],
-            ) if (type_name := self._resolve_type(instance_name)) is not None:
-                return cst.Call(
-                    func=cst.Attribute(
-                        value=cst.Name(type_name),
-                        attr=cst.Name("__getitem__"),
-                    ),
-                    args=[
-                        cst.Arg(value=cst.Integer(value=args)),
-                    ],
-                )
-            case cst.Subscript(  # Variable index
-                value=cst.Name(value=instance_name),
-                slice=[
-                    cst.SubscriptElement(slice=cst.Index(value=cst.Name(value=args)))
-                ],
-            ) if (type_name := self._resolve_type(instance_name)) is not None:
-                res_args: int | str | object = self.user_namespace.get(args, args)
-                if isinstance(res_args, int):
-                    mval: cst.BaseExpression = cst.Integer(value=f"{res_args}")
-                else:
-                    mval = cst.SimpleString(value=f"'{res_args}'")
-                return cst.Call(
-                    func=cst.Attribute(
-                        value=cst.Name(type_name),
-                        attr=cst.Name("__getitem__"),
-                    ),
-                    args=[
-                        cst.Arg(
-                            value=mval
-                        ),  # TODO: so we can put the right value in here
-                    ],
-                )
-            # Explicitly handle the case of `intake.cat.access_nri['something']
-            case cst.Subscript(
-                value=cst.Attribute(
-                    value=cst.Attribute(
-                        value=cst.Name(value="intake"),
-                        attr=cst.Name(value="cat"),
-                    ),
-                    attr=cst.Name(
-                        value="access_nri",
-                    ),
-                ),
-                slice=[
-                    cst.SubscriptElement(
-                        slice=cst.Index(value=cst.SimpleString(value=arg)),
-                    ),
-                ],
-            ):
-                self._process_api_call("intake.cat.access_nri", [], {})
-                return self._process_subscript_call("DfFileCatalog", updated_node, arg)
-            case cst.Subscript(
-                value=cst.Attribute(
-                    value=cst.Attribute(
-                        value=cst.Name(
-                            value="intake",
-                        ),
-                        attr=cst.Name(
-                            value="cat",
-                        ),
-                    ),
-                    attr=cst.Name(
-                        value="access_nri",
-                    ),
-                ),
-                slice=[
-                    cst.SubscriptElement(
-                        slice=cst.Index(
-                            value=cst.Name(
-                                value=arg,
-                            ),
-                        ),
-                    ),
-                ],
-            ) if (argval := self.user_namespace.get(arg, None)) is not None:
-                # Differs from above as we need to wrap arg in extra quotes to rewrite
-                # it as a simple string in the rewritten code.
-                self._process_api_call("intake.cat.access_nri", [], {})
-                return self._process_subscript_call(
-                    "DfFileCatalog", updated_node, f"'{argval}'"
-                )
-            case _:  # pragma: no cover
-                raise AssertionError(
-                    "Subscript node does not match expected pattern. "
-                    "This should not happen, please report this as a bug."
-                )  # pragma: no cover
-
-    def _process_subscript_call(
-        self, type_name: str, updated_node: cst.Subscript, arg: str
-    ) -> cst.Name:
-        _node = cst.Call(
-            func=cst.Attribute(
-                value=cst.Name(type_name),
-                attr=cst.Name("__getitem__"),
-            ),
-            args=[
-                cst.Arg(value=cst.SimpleString(value=arg)),
-            ],
-        )
-        full_name = f"{type_name}.__getitem__"
-        _args, _ = extract_call_args_kwargs(_node, self.user_namespace)
-        self._process_api_call(full_name, _args, {})
-
-        temp_module = cst.Module(
-            body=[cst.SimpleStatementLine(body=[cst.Expr(value=updated_node)])]
-        )
-        code = temp_module.code
-        try:
-            result_type = type(eval(code, globals(), self.user_namespace)).__name__
-        except Exception:  # pragma: no cover
-            result_type = type_name  # pragma: no cover
-
-        return cst.Name(value=result_type)
-
-    def leave_Call(
-        self, original_node: cst.Call, updated_node: cst.Call
-    ) -> cst.Call | cst.Name:
-        # Use matcher to identify the pattern: any_method(search_call(...))
-
-        match updated_node:
-            case cst.Call(
-                func=cst.Name(
-                    value=func_name,
-                )
-            ) if (instance := self.user_namespace.get(func_name, None)) is not None:
-                func_name = (
-                    instance.__name__
-                )  # Dealias if we've renamed it something else
-                return updated_node.with_changes(func=cst.Name(func_name))
-            case cst.Call(
-                func=cst.Attribute(
-                    value=cst.Name(value=base_name),
-                    attr=cst.Name(
-                        value=attr_name,
-                    ),
-                )
-            ):  # TODO: check that we return self here or don't do anything
-                args, kwargs = extract_call_args_kwargs(
-                    updated_node, self.user_namespace
-                )
-                full_name = f"{base_name}.{attr_name}"
-                self._process_api_call(full_name, args, kwargs)
-                # Then pop that attribute access out of the chain
-                return cst.Name(
-                    value=base_name,
-                )
-            case _:
-                pass
-
-        return updated_node
-
-    def _process_api_call(
-        self, func_name: str, args: list[Any], kwargs: dict[str, Any]
-    ) -> None:
-        """Process an API call for a matched function name."""
-        for registry, registered_funcs in self.registries.items():
-            if func_name in registered_funcs:
-                self.api_handler.send_api_request(
-                    registry,
-                    func_name,
-                    args,
-                    kwargs,
-                )
-                self._caught_calls |= {func_name}
-
-
-def _get_full_name(node: cst.CSTNode) -> str:
-    """Recursively get the full name of a function or method call."""
-    match node:
-        case cst.Attribute(
-            value=base_name,
-            attr=cst.Name(value=attr_name),
-        ):
-            # If the node is an attribute, we need to repeat to get the full name
-            return f"{_get_full_name(base_name)}.{attr_name}"
-        case cst.Name(value=name):
-            # If the node is a name, we return the name
-            assert isinstance(name, str), "Name node should have a string value"
-            return name
-        case _:  # pragma: no cover
-            raise AssertionError(
-                "Node does not match expected pattern. "
-                "This should not happen, please report this as a bug."
-            )  # pragma: no cover

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
 # type: ignore
 
-"""Tests for the AST module"""
-
-import sys
-from unittest.mock import MagicMock, patch
-from unittest.mock import call as unittest_call
+"""Tests for the AST module (typed transition interpreter)."""
 
 import libcst as cst
 import pytest
 
 from access_py_telemetry.ast import (
-    CallListener,
-    ChainSimplifier,
+    Dotted,
+    Node,
     capture_registered_calls,
+    interpret,
     strip_magic,
 )
 
@@ -23,9 +20,24 @@ class MockInfo:
         self.raw_cell = raw_cell
 
 
-def test_ast_instance_method():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def events_for(code, registry, ns=None):
+    """Interpret ``code`` against a single-service ``registry`` and return events."""
+    tree = cst.parse_module(code)
+    return interpret(tree, {"mock": set(registry)}, ns or {})
+
+
+def caught(code, registry, ns=None):
+    """The set of registered names detected in ``code``."""
+    return {event.name for event in events_for(code, registry, ns)}
+
+
+def test_same_cell_instantiation():
+    """
+    The motivating case: an object is instantiated in the *same* cell as the
+    method call. `pre_run_cell` fires before execution, so the namespace can't
+    help — the type is resolved statically from the constructor. No namespace.
+    """
+    code = """
 class MyClass:
     def func(self):
         self.set_var = set()
@@ -34,86 +46,33 @@ class MyClass:
         pass
 
 instance = MyClass()
-mycall = instance.func()
-
+instance.func()
 instance.uncaught_func()
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.func"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "MyClass.func",
-    }
-
-    assert "MyClass.uncaught_func" not in visitor._caught_calls
+    assert caught(code, ["MyClass.func"]) == {"MyClass.func"}
+    assert "MyClass.uncaught_func" not in caught(code, ["MyClass.func"])
 
 
-def test_ast_bare_function_args_kwargs():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
-def registered_func(*args, **kwargs):
-    return None
-
-x = 1
-y = "a_str"
-z = ["a", "list", 0, "random", ["values", "and", "types"]]
-
-registered_func(x, y=y, z=z)
-
-"""
-
-    called_with = (
-        "mock",
-        "registered_func",
-        [1],
-        {"y": "a_str", "z": ["a", "list", 0, "random", ["values", "and", "types"]]},
-    )
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["registered_func"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "registered_func",
-    }
-
-    mock_api_handler.send_api_request.assert_called_once_with(*called_with)
+def test_instance_method_from_namespace():
+    """An object created in an earlier cell is typed via the namespace fallback."""
+    code = "instance.func()\n"
+    ns = {"instance": type("MyClass", (), {})()}
+    assert caught(code, ["MyClass.func"], ns) == {"MyClass.func"}
 
 
-def test_ast_unparse_bare_function():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_bare_function_args_kwargs():
+    code = "registered_func(x, y=y, z=z)\n"
+    ns = {"x": 1, "y": "a_str", "z": ["a", "list", 0, "random", ["values"]]}
+    events = events_for(code, ["registered_func"], ns)
+    assert len(events) == 1
+    event = events[0]
+    assert event.name == "registered_func"
+    assert event.args == [1]
+    assert event.kwargs == {"y": "a_str", "z": ["a", "list", 0, "random", ["values"]]}
 
+
+def test_unparse_bare_function():
+    code = """
 import pandas as pd
 
 def registered_func():
@@ -122,50 +81,22 @@ def registered_func():
 def registered_func2(x):
     return None
 
-
 def unregistered_func():
     return None
 
 registered_func()
 unregistered_func()
-
 registered_func2(pd.DataFrame())
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["registered_func", "registered_func2"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    assert caught(code, ["registered_func", "registered_func2"]) == {
         "registered_func",
         "registered_func2",
     }
 
-    assert "uncaught_func" not in visitor._caught_calls
 
-
-def test_ast_aliased_function():
-    """
-    This will require more sophisticated analysis to catch aliased functions. Maybe
-    we can look at this eventually
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_aliased_function():
+    """A function rebound to a new name is dealiased through the binding env."""
+    code = """
 def registered_func():
     return None
 
@@ -173,113 +104,41 @@ reg_func = registered_func
 
 reg_func()
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["registered_func"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "registered_func",
-    }
+    assert caught(code, ["registered_func"]) == {"registered_func"}
 
 
-def test_ast_instantiate_and_call():
-    """
-    Need to figure out how to catch the instantiation of a class and then call a method
-    on it. Not needed yet
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_instantiate_and_call():
+    code = "MyClass().func()\n"
+    ns = {"MyClass": type("MyClass", (), {})}
+    assert caught(code, ["MyClass.func"], ns) == {"MyClass.func"}
+
+
+def test_instantiate_and_call_same_cell():
+    code = """
 class MyClass:
     def func(self):
         self.set_var = set()
 
 MyClass().func()
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.func"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "MyClass.func",
-    }
+    assert caught(code, ["MyClass.func"]) == {"MyClass.func"}
 
 
-def test_ast_class_method():
-    """
-    Class methods don't work with the CallListener yet
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_class_method():
+    code = """
 class MyClass:
     @classmethod
     def func(cls):
         cls.set_var = set()
 
 MyClass.func()
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.func"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "MyClass.func",
-    }
+    assert caught(code, ["MyClass.func"]) == {"MyClass.func"}
 
 
-def test_ast_indexing():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_indexing():
+    code = """
 class MyClass:
-    def func(self):
-        self.set_var = set()
-
     def __getitem__(self, key):
         return [1, 2, 3]
 
@@ -287,108 +146,38 @@ instance = MyClass()
 mycall = instance['some_item']
 
 l = [1, 2, 3]
-
 l[0]
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.__getitem__", "list.__getitem__"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    assert caught(code, ["MyClass.__getitem__", "list.__getitem__"]) == {
         "MyClass.__getitem__",
         "list.__getitem__",
     }
 
 
-def test_ast_nested_function():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_nested_function():
+    code = """
 import os
 
-os.path.join("some","paths")
-
+os.path.join("some", "paths")
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["os.path.join"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "os.path.join",
-    }
+    assert caught(code, ["os.path.join"]) == {"os.path.join"}
 
 
-def test_ast_aliased_module():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+def test_aliased_module():
+    code = """
 import os as operating_system
 
-operating_system.path.join("some","paths")
-
+operating_system.path.join("some", "paths")
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["os.path.join"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "os.path.join",
-    }
+    assert caught(code, ["os.path.join"]) == {"os.path.join"}
 
 
 @pytest.mark.parametrize(
-    "raw_cell, called_with",
+    "raw_cell, expected",
     [
         (
             """
 class MyClass:
-    def func(self):
-        self.set_var = set()
-
     def __getitem__(self, key):
         return [1, 2, 3]
 
@@ -398,14 +187,11 @@ search_str = 'some_item'
 
 mycall = instance[search_str]
 """,
-            ("mock", "MyClass.__getitem__", ["'some_item'"], {}),
+            ("MyClass.__getitem__", ["'some_item'"], {}),
         ),
         (
             """
 class MyClass:
-    def func(self):
-        self.set_var = set()
-
     def __getitem__(self, key):
         return [1, 2, 3]
 
@@ -413,300 +199,130 @@ instance = MyClass()
 
 mycall = instance['directly_used_string']
 """,
-            ("mock", "MyClass.__getitem__", ["'directly_used_string'"], {}),
+            ("MyClass.__getitem__", ["'directly_used_string'"], {}),
         ),
         (
             """
-l = [0,1,2,3]
+l = [0, 1, 2, 3]
 
 MAGIC_NUMBER = 1
 
 l[MAGIC_NUMBER]
 """,
-            ("mock", "list.__getitem__", ["1"], {}),
+            ("list.__getitem__", ["1"], {}),
         ),
     ],
 )
-def test_ast_aliased_index(raw_cell, called_with):
+def test_indexing_args(raw_cell, expected):
     """
-    We need to make sure that we properly catch, eg.
-    ```python
-    experiment_name = 'my_expt'
-    esm_ds = catalog[experiment_name]
-    ```
-    and record the call to catalog.__getitem_ with an argument of 'my_expt'
-    rather than the string identifier of the variable holding it, `experiment_name`
+    An index argument is recorded as its value (`'my_expt'`), whether written
+    directly or held in a same-cell variable — never the variable identifier.
     """
-
-    mock_info = MockInfo()
-    mock_info.raw_cell = raw_cell
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.__getitem__", "list.__getitem__"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    mock_api_handler.send_api_request.assert_called_once_with(*called_with)
+    events = events_for(raw_cell, ["MyClass.__getitem__", "list.__getitem__"])
+    assert len(events) == 1
+    event = events[0]
+    assert (event.name, event.args, event.kwargs) == expected
 
 
 def test_import_catalog():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 import intake
 intake.cat.access_nri
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["intake.cat.access_nri"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "intake.cat.access_nri",
-    }
+    assert caught(code, ["intake.cat.access_nri"]) == {"intake.cat.access_nri"}
 
 
 def test_import_assign_catalog():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 import intake
 cat = intake.cat.access_nri
-
 """
+    assert caught(code, ["intake.cat.access_nri"]) == {"intake.cat.access_nri"}
 
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
 
-    mock_registry = {"mock": ["intake.cat.access_nri"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "intake.cat.access_nri",
-    }
+def test_import_assign_catalog_types_variable():
+    """Assigning the generator result binds the variable's node type."""
+    tree = cst.parse_module("import intake\ncat = intake.cat.access_nri\n")
+    interp_events = interpret(tree, {"mock": {"intake.cat.access_nri"}}, {})
+    assert len(interp_events) == 1
 
 
 def test_index_return_self_and_chained_call():
     """
-    Test that we can catch a chained cal where the first call is an indexing operation
-    that returns self, and then a method is called on it. This is to test that the ChainSimplifier
-    correctly simplifies the chain and allows us to catch both calls.
-
+    A chained call whose first link is an index that returns self, then a method
+    on the result. The __getitem__ defaults to returning self, so both are caught.
     """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 class MyClass:
     def __getitem__(self, key):
-        # Just return self - this is a dummy method for a test
         return self
 
     def compute(self, *args, **kwargs):
-        # Just return a random number - this is a dummy method for a test
         import random
         return random.random()
 
 c = MyClass()
 random_num = c['some_item'].compute()
-#random_num = MyClass()['some_item'].compute()
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.__getitem__", "MyClass.compute"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    assert caught(code, ["MyClass.__getitem__", "MyClass.compute"]) == {
         "MyClass.__getitem__",
         "MyClass.compute",
     }
 
 
 def test_instantiate_index_and_chained_call():
-    """
-    Same as above, except this time we haven't stored the instance of MyClass in
-    an intermediate variable
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 class MyClass:
     def __getitem__(self, key):
-        # Just return self - this is a dummy method for a test
         return self
 
     def compute(self, *args, **kwargs):
-        # Just return a random number - this is a dummy method for a test
         import random
         return random.random()
 
 random_num = MyClass()['some_item'].compute()
-
 """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["MyClass.__getitem__", "MyClass.compute"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    assert caught(code, ["MyClass.__getitem__", "MyClass.compute"]) == {
         "MyClass.__getitem__",
         "MyClass.compute",
     }
 
 
 def test_import_and_index_into_catalog():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    """intake.cat.access_nri['x'] catches the generator and the __getitem__ edge."""
+    code = """
 import intake
 try:
     intake.cat.access_nri['some_item']
 except Exception:
     pass
-
 """
-
-    mock_type_result = MagicMock()
-    mock_type_result = type("esm_datastore", (), {})()
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["intake.cat.access_nri", "DfFileCatalog.__getitem__"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    with patch("access_py_telemetry.ast.eval", return_value=mock_type_result):
-        reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-        reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    registry = ["intake.cat.access_nri", "DfFileCatalog.__getitem__"]
+    assert caught(code, registry) == {
         "intake.cat.access_nri",
         "DfFileCatalog.__getitem__",
     }
 
 
 def test_import_stringindex_and_search():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 import intake
 try:
     intake.cat.access_nri['some_item'].search(file_id='xyz').to_dask()
 except Exception:
     pass
-
 """
-
-    mock_type_result = MagicMock()
-    mock_type_result = type("esm_datastore", (), {})()
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {
-        "mock": [
-            "intake.cat.access_nri",
-            "DfFileCatalog.__getitem__",
-            "esm_datastore.search",
-            "esm_datastore.to_dask",
-        ]
-    }
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    with patch("access_py_telemetry.ast.eval", return_value=mock_type_result):
-        reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-        reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    registry = [
         "intake.cat.access_nri",
         "DfFileCatalog.__getitem__",
         "esm_datastore.search",
         "esm_datastore.to_dask",
-    }
+    ]
+    assert caught(code, registry) == set(registry)
 
 
 def test_import_stringindex_save_and_search():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 import intake
 try:
     datastore = intake.cat.access_nri["1deg_era5_iaf"]
@@ -715,139 +331,88 @@ try:
     ).to_dask()
 except Exception:
     pass
-
 """
-
-    mock_type_result = MagicMock()
-    mock_type_result = type("esm_datastore", (), {})()
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {
-        "mock": [
-            "intake.cat.access_nri",
-            "DfFileCatalog.__getitem__",
-            "esm_datastore.search",
-            "esm_datastore.to_dask",
-        ]
-    }
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    with patch("access_py_telemetry.ast.eval", return_value=mock_type_result):
-        reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-        reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    registry = [
         "intake.cat.access_nri",
         "DfFileCatalog.__getitem__",
         "esm_datastore.search",
         "esm_datastore.to_dask",
-    }
+    ]
+    assert caught(code, registry) == set(registry)
 
 
 def test_import_varindex_and_search():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
+    code = """
 import intake
 source = 'some_item'
 try:
     intake.cat.access_nri[source].search(file_id='xyz').to_dask()
 except Exception:
     pass
-
 """
-
-    mock_type_result = MagicMock()
-    mock_type_result = type("esm_datastore", (), {})()
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {
-        "mock": [
-            "intake.cat.access_nri",
-            "DfFileCatalog.__getitem__",
-            "esm_datastore.search",
-            "esm_datastore.to_dask",
-        ]
-    }
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    with patch("access_py_telemetry.ast.eval", return_value=mock_type_result):
-        reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-        reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
+    registry = [
         "intake.cat.access_nri",
         "DfFileCatalog.__getitem__",
         "esm_datastore.search",
         "esm_datastore.to_dask",
-    }
+    ]
+    assert caught(code, registry) == set(registry)
 
 
-@pytest.mark.xfail
-def test_import_catalog_traverse_imports():
-    """
-    This fails because the CallListener doesn't traverse the imports yet. We can
-    do this using importlib and then parsing what importlib imports too I think,
-    but let's save that for another day
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
-import intake
-intake.cat.access_nri
+def test_implicit_boolean_conversion():
+    """`arr = np.array(...)` is untypeable statically, so `arr` falls back to the
+    namespace, where its runtime type is `ndarray`."""
+    code = """
+arr = np.array([0, 2, 3])
+arr.mean()
 """
+    ns = {"np": type("np_module", (), {})(), "arr": type("ndarray", (), {})()}
+    assert caught(code, ["ndarray.mean"], ns) == {"ndarray.mean"}
 
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
 
-    mock_registry = {"mock": ["intake.catalog.Catalog.__init__"]}
+def test_chained_function_call():
+    """
+    The most 'real life' test: a chained call is caught with the calls recorded
+    in the right order.
+    """
+    code = """
+class esm_datastore:
+    def search(self, **kwargs):
+        return self
 
-    mock_api_handler = MagicMock()
+    def to_dask(self, **kwargs) -> None:
+        return None
 
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
+esm_ds = esm_datastore()
 
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
+time = '2023-01-01'
 
-    visitor._caught_calls |= reducer._caught_calls
+ds = esm_ds.search(
+    file_id='xyz'
+).search(
+    start_date=time
+).to_dask(
+    xarray_open_kwargs = {'chunks' : 'auto'}
+)
+"""
+    registry = ["esm_datastore.search", "esm_datastore.to_dask"]
+    events = events_for(code, registry)
 
-    assert visitor._caught_calls == {
-        "intake.cat.access_nri",
+    assert {e.name for e in events} == {
+        "esm_datastore.search",
+        "esm_datastore.to_dask",
     }
+    ordered = [(e.name, e.args, e.kwargs) for e in events]
+    assert ordered == [
+        ("esm_datastore.search", [], {"file_id": "'xyz'"}),
+        ("esm_datastore.search", [], {"start_date": "2023-01-01"}),
+        ("esm_datastore.to_dask", [], {"xarray_open_kwargs": {"chunks": "auto"}}),
+    ]
 
 
 def test_match_ipython_magic():
-    """
-    This test is to check that the IPython magic commands are not caught by the
-    CallListener. This is important because we don't want to send telemetry for
-    IPython magic commands.
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = r"""
+    """IPython magic lines are stripped before parsing."""
+    raw_cell = r"""
 !ls
 %%timeit
 class MyClass:
@@ -879,7 +444,7 @@ MyClass.func(instance)
 
     """
 
-    parsed_w_magic = strip_magic(mock_info.raw_cell)
+    parsed_w_magic = strip_magic(raw_cell)
     parsed_wo_magic = strip_magic(python_code)
 
     assert parsed_w_magic == parsed_wo_magic
@@ -890,237 +455,34 @@ MyClass.func(instance)
 
 
 def test_parse_invalid_code():
+    """Invalid code must not raise out of the hook."""
     mock_info = MockInfo()
     mock_info.raw_cell = """
 class MyClass:
     def func(self):
         self.set_var = set()
-
-    def uncaught_func(self, *args, **kwargs):
-        pass
 
 instance = MyClass()
 mycall = instance.func()
 
     instance.uncaught_func()
-
-
 """
-
     capture_registered_calls(mock_info)
 
     mock_info = MockInfo()
     mock_info.raw_cell = """
-class MyClass:
-    def func(self):
-        self.set_var = set()
-
-    def uncaught_func(self, *args, **kwargs):
-        pass
-
 @instance = MyClass()
 1mycall = instance.func()
-
-    instance.uncaught_func()
-
-
 """
-
     capture_registered_calls(mock_info)
 
 
-def test_implicit_boolean_conversion():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
-
-import numpy as np
-
-arr = np.array([0, 2, 3])
-
-arr.mean()
-
-"""
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["ndarray.mean"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {"ndarray.mean"}
+def test_none_cell_is_noop():
+    """A cell with no source is a no-op."""
+    assert capture_registered_calls(MockInfo(raw_cell=None)) is None
 
 
-def test_ChainSimplifier_instance_to_classname():
-    """
-    Test that the ChainSimplifier correctly converts instance method calls to class names.
-    """
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
-class MyClass:
-    def __init__(self):
-        self.a = "value"
-
-    def func1(self):
-        return self
-
-    def func2(self):
-        return self
-
-instance = MyClass()
-instance.func1().func2() # These should be popped out by the ChainSimplifier
-
-instance.a
-"""
-
-    transformed_cell = """
-class MyClass:
-    def __init__(self):
-        self.a = "value"
-
-    def func1(self):
-        return self
-
-    def func2(self):
-        return self
-
-instance = MyClass()
-MyClass # These should be popped out by the ChainSimplifier
-
-MyClass.a
-"""
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["ndarray.mean"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-
-    code = reduced_tree.code
-
-    assert code == transformed_cell
-
-
-def test_ChainSimplifier_indexing():
-    mock_info = MockInfo()
-    mock_info.raw_cell = """
-l = [1, 2, 3]
-
-l[0]
-    """
-
-    transformed_cell = """
-l = [1, 2, 3]
-
-list.__getitem__(0)
-    """
-
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["ndarray.mean"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-
-    code = reduced_tree.code
-
-    assert code == transformed_cell
-
-
-@pytest.mark.parametrize(
-    "raw_cell, called_with",
-    [
-        (
-            """
-# Mock the esm_datastore instead of creating it from a file
-class esm_datastore:
-    def search(self, **kwargs):
-        return self
-
-    def to_dask(self, **kwargs) -> None:
-        return None
-
-esm_ds = esm_datastore()
-
-time = '2023-01-01'
-
-ds = esm_ds.search(
-    file_id='xyz'
-).search(
-    start_date=time
-).to_dask(
-    xarray_open_kwargs = {'chunks' : 'auto'}
-)
-""",
-            [
-                ("mock", "esm_datastore.search", [], {"file_id": "'xyz'"}),
-                ("mock", "esm_datastore.search", [], {"start_date": "2023-01-01"}),
-                (
-                    "mock",
-                    "esm_datastore.to_dask",
-                    [],
-                    {"xarray_open_kwargs": {"chunks": "auto"}},
-                ),
-            ],
-        ),
-    ],
-)
-def test_chained_function_call(raw_cell, called_with):
-    """
-    This is going to be our most 'real life' test. We want to make sure that
-    something like `esm_datastore.search(file_id='xyz').search(start_date=time).to_dask()`
-    is properly caught and the calls are registered correctly - and in the right
-    order.
-    """
-
-    mock_info = MockInfo()
-    mock_info.raw_cell = raw_cell
-    f = sys._getframe()
-    exec(mock_info.raw_cell, globals(), f.f_locals)
-    mock_user_ns = f.f_locals
-
-    mock_registry = {"mock": ["esm_datastore.search", "esm_datastore.to_dask"]}
-
-    mock_api_handler = MagicMock()
-
-    tree = cst.parse_module(mock_info.raw_cell)
-    reducer = ChainSimplifier(mock_user_ns, mock_registry, mock_api_handler)
-    reduced_tree = tree.visit(reducer)
-    wrapper = cst.MetadataWrapper(reduced_tree)
-
-    visitor = CallListener(mock_user_ns, mock_registry, mock_api_handler)
-    wrapper.visit(visitor)
-
-    visitor._caught_calls |= reducer._caught_calls
-
-    assert visitor._caught_calls == {
-        "esm_datastore.search",
-        "esm_datastore.to_dask",
-    }
-
-    assert mock_api_handler.send_api_request.call_count == 3
-
-    mock_api_handler.send_api_request.assert_has_calls(
-        [unittest_call(*call) for call in called_with],
-    )
+def test_abstract_values_smoke():
+    """The abstract value dataclasses are importable and comparable."""
+    assert Node("esm_datastore") == Node("esm_datastore")
+    assert Dotted("os.path") != Dotted("os")


### PR DESCRIPTION
**Stack 4/4** — base: `telemetry/transition-table` (#100)

Replaces the two-pass CST-rewriting detector (`ChainSimplifier` + `CallListener`) with a single **pure interpreter** that walks the cell in evaluation order, tracking a type environment (name → telemetry node type) and a value environment (name → literal, for args). Registered calls become emitting edges in the transition table from #100, so `cat = intake.cat.access_nri; cat[...].search(...).to_dask()` resolves the whole chain and emits events in source order.

### Why
The old detector typed receivers by reading the live IPython namespace, which **fails on same-cell instantiation** — `pre_run_cell` fires *before* the cell runs, so an object created in the same cell isn't in `user_ns` yet. The new walk binds types syntactically, so same-cell construction just works; `user_ns` is now only a lazy fallback for objects born in an earlier cell.

### What
- `interpret(tree, registries, user_ns) -> list[TelemetryEvent]` is pure and directly snapshot-testable (no `exec`, no `MagicMock`); `_dispatch` is the thin I/O layer that posts each event.
- `capture_registered_calls` keeps `strip_magic` and the parse-error → `send_failure_api_request` path unchanged.
- Deletes `ChainSimplifier`, `CallListener`, `_run_tree`, and the subscript `eval`; `extract_call_args_kwargs` is reused for args.
- Tests rewritten onto the pure `source -> ordered events` surface, including the previously inexpressible same-cell-instantiation case.

> **Note on size:** this PR is unavoidably large — it's a wholesale replacement of the detection engine (the old and new engines can't coexist in a working intermediate). The three preceding PRs carved off everything that *could* be separated. `plans/telemetry-transition-ir.md` documents the design; drop that file if you'd rather not track it.

Full suite green (71 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)